### PR TITLE
fix!: recreate mock on reset()

### DIFF
--- a/src/awsClientStub.ts
+++ b/src/awsClientStub.ts
@@ -66,12 +66,6 @@ export class AwsStub<TInput extends object, TOutput extends MetadataBearer> impl
         return this;
     }
 
-    /** Resets stub's behavior. */
-    resetBehavior(): AwsStub<TInput, TOutput> {
-        this.send.resetBehavior();
-        return this;
-    }
-
     /** Resets stub's calls history. */
     resetHistory(): AwsStub<TInput, TOutput> {
         this.send.resetHistory();

--- a/src/awsClientStub.ts
+++ b/src/awsClientStub.ts
@@ -131,8 +131,6 @@ export class AwsStub<TInput extends object, TOutput extends MetadataBearer> impl
      * Allows specifying the behavior for any Command with given input (parameters).
      *
      * If the input is not specified, the given behavior will be used for any Command with any input.
-     * This is no different from using {@link resolves}, {@link rejects}, etc. directly,
-     * but can be used for readability.
      * @param input Command payload to match
      * @param strict Should the payload match strictly (default false, will match if all defined payload properties match)
      */
@@ -149,27 +147,33 @@ export class AwsStub<TInput extends object, TOutput extends MetadataBearer> impl
 
     /**
      * Sets a successful response that will be returned from any `Client#send()` invocation.
+     *
+     * Same as `mock.onAnyCommand().resolves()`.
      * @param response Content to be returned
      */
     resolves(response: CommandResponse<TOutput>): AwsStub<TInput, TOutput> {
-        return this.anyCommandBehavior.resolves(response);
+        return this.onAnyCommand().resolves(response);
     }
 
     /**
      * Sets a failure response that will be returned from any `Client#send()` invocation.
      * The response will always be an `Error` instance.
+     *
+     * Same as `mock.onAnyCommand().rejects()`.
      * @param error Error text, Error instance or Error parameters to be returned
      */
     rejects(error?: string | Error | AwsError): AwsStub<TInput, TOutput> {
-        return this.anyCommandBehavior.rejects(error);
+        return this.onAnyCommand().rejects(error);
     }
 
     /**
      * Sets a function that will be called on any `Client#send()` invocation.
+     *
+     * Same as `mock.onAnyCommand().callsFake()`.
      * @param fn Function taking Command input and returning result
      */
     callsFake(fn: (input: any) => any): AwsStub<TInput, TOutput> {
-        return this.anyCommandBehavior.callsFake(fn);
+        return this.onAnyCommand().callsFake(fn);
     }
 
 }

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -21,7 +21,7 @@ export const mockClient = <TInput extends object, TOutput extends MetadataBearer
 
     const sendStub = stub(instance, 'send') as SinonStub<[Command<TInput, any, TOutput, any, any>], Promise<TOutput>>;
 
-    return new AwsStub<TInput, TOutput>(sendStub);
+    return new AwsStub<TInput, TOutput>(instance, sendStub);
 };
 
 type ClassType<T> = {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,6 +1,7 @@
 import {PublishCommand} from '@aws-sdk/client-sns';
 
 export const topicArn = 'arn:aws:sns:us-east-1:111111111111:MyTopic';
+export const topicArn2 = 'arn:aws:sns:us-east-1:111111111111:MyOtherTopic';
 
 export const publishCmd1 = new PublishCommand({
     TopicArn: topicArn,
@@ -9,6 +10,10 @@ export const publishCmd1 = new PublishCommand({
 export const publishCmd2 = new PublishCommand({
     TopicArn: topicArn,
     Message: 'second mock message',
+});
+export const publishCmd3 = new PublishCommand({
+    TopicArn: topicArn2,
+    Message: 'third mock message',
 });
 
 export const uuid1 = '12345678-1111-2222-3333-111122223333';

--- a/test/mockClient.regression.test.ts
+++ b/test/mockClient.regression.test.ts
@@ -1,0 +1,53 @@
+import {AwsClientStub, mockClient} from '../src';
+import {PublishCommand, SNSClient} from '@aws-sdk/client-sns';
+import {publishCmd1, publishCmd3, topicArn} from './fixtures';
+
+let snsMock: AwsClientStub<SNSClient>;
+
+beforeEach(() => {
+    snsMock = mockClient(SNSClient);
+});
+
+afterEach(() => {
+    snsMock.restore();
+});
+
+/**
+ * Sinon.JS has a bug with a sinon.match breaking subsequent mocks in some scenarios,
+ * including leaking the mock behaviors between the stub.reset() calls.
+ * See: https://github.com/m-radzikowski/aws-sdk-client-mock/issues/67 and https://github.com/sinonjs/sinon/issues/1572
+ */
+describe('issue 67 - breaking subsequent mocks', () => {
+    const sns = new SNSClient({});
+
+    /**
+     * This corresponds to the pattern with mock.reset() and mock.onAnyCommand().rejects()
+     * being called in the beforeEach() block and then individual mock behaviors being set in test functions.
+     */
+    test('resetting mock does not break subsequent mocks', async () => {
+        snsMock.onAnyCommand().rejects('any command error');
+        snsMock.on(PublishCommand).rejects('publish error');
+
+        snsMock.reset();
+        snsMock.onAnyCommand().rejects('any command error');
+
+        const publish = sns.send(publishCmd1);
+
+        await expect(publish).rejects.toThrow('any command error');
+    });
+
+    /**
+     * Make sure the main behavior described in the Sinon.JS bug, with match.any breaking subsequent stubs,
+     * does not happen.
+     */
+    test('onAnyCommand does not brake other mocks', async () => {
+        snsMock.onAnyCommand().rejects('any command error');
+        snsMock.onAnyCommand({TopicArn: topicArn}).rejects('any command first topic error');
+
+        const publish1 = sns.send(publishCmd1);
+        const publish2 = sns.send(publishCmd3);
+
+        await expect(publish1).rejects.toThrow('any command first topic error');
+        await expect(publish2).rejects.toThrow('any command error');
+    });
+});

--- a/test/mockClient.test.ts
+++ b/test/mockClient.test.ts
@@ -21,22 +21,6 @@ describe('setting up the mock', () => {
         expect(publish).toBeUndefined();
     });
 
-    it('resets mock behavior', async () => {
-        snsMock.resolves({
-            MessageId: uuid1,
-        });
-
-        const sns = new SNSClient({});
-        const publish1 = await sns.send(publishCmd1);
-
-        snsMock.resetBehavior();
-
-        const publish2 = await sns.send(publishCmd2);
-
-        expect(publish1.MessageId).toBe(uuid1);
-        expect(publish2).toBeUndefined();
-    });
-
     it('resets mock behavior on mock reset', async () => {
         snsMock.resolves({
             MessageId: uuid1,


### PR DESCRIPTION
The #67 turned out to be a consequence of a well-known Sinon.JS bug https://github.com/sinonjs/sinon/issues/1572

The Sinon bug consequences are limited since we always use `sinon.match` expressions, but in some scenarios, the `reset()` could not clean the stub properly and have the behavior leak between the tests. To solve this, now the Sinon stub is recreated on calling `reset()`.

Because of the Sinon.JS bug, the `resetBehavior()` method, calling Sinon.JS `stub.resetBehavior()`, cannot be relied upon and is removed, since there is no easy fix for it.

Fixes #67 