### PR TITLE
build: omit "/src" in published packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
   "main": "dist/cjs/index.js",
   "types": "dist/types/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@types/jest": "^28.1.3",


### PR DESCRIPTION
Jest sometimes ignores the pakage.json's entry/main values. It tries to import a `.ts` path at runtime: `aws-sdk-client-mock/src/sinon.ts` 

I've looked at the compiled JS on NPM, and there's no obvious issue with the paths for either the CJS or ESM build.

### The (simple) fix

Omit the `src` folder from npm publish (see `files` field in package.json.) Ideally the compiled `dist` folder should include everything NPM requires.

This change is low risk as src files shouldn't be included anyway. Source maps give us the full experience of having the code without actually baking it in.

**As a bonus, this reduces the package/bundle size by _~25%!_**


### More details:

```bash
Jest encountered an unexpected token

Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

By default "node_modules" folder is ignored by transformers.

Here's what you can do:
  • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
  • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
  • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
  • If you need a custom transformation specify a "transform" option in your config.
  • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

You'll find more details and examples of these config options in the docs:
https://jestjs.io/docs/configuration
For information about custom transformations, see:
https://jestjs.io/docs/code-transformation

Details:

SyntaxError: <PROJECT_DIR>/node_modules/aws-sdk-client-mock/src/sinon.ts: Support for the experimental syntax 'flow' isn't currently enabled (3:8):

  1 | import {SinonStub} from 'sinon';
  2 |
> 3 | export interface MaybeSinonProxy {
    |        ^
  4 |     isSinonProxy?: boolean;
  5 | }
  6 |

Add @babel/preset-flow (https://git.io/JfeDn) to the 'presets' section of your Babel config to enable transformation.
If you want to leave it as-is, add @babel/plugin-syntax-flow (https://git.io/vb4yb) to the 'plugins' section to enable parsing.

  at instantiate (node_modules/jest-runner/node_modules/@babel/parser/src/parse-error/credentials.js:61:22)
```




