### PR TITLE
feat: support Jest asymmetric matchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "husky": "7.0.4",
     "jest": "28.1.1",
     "lint-staged": "11.1.2",
+    "pretty-format": "28.1.1",
     "rimraf": "3.0.2",
     "size-limit": "5.0.3",
     "standard-version": "9.3.1",
@@ -84,6 +85,9 @@
     "modulePathIgnorePatterns": [
       "test-e2e",
       "verdaccio-storage"
+    ],
+    "snapshotSerializers": [
+      "./node_modules/pretty-format/build/plugins/ConvertAnsi.js"
     ]
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky install",
     "ci": "yarn install --frozen-lockfile",
     "pretest": "rimraf coverage/",
-    "test": "jest --coverage",
+    "test": "jest --coverage --colors",
     "test-types": "tsd",
     "test-e2e": "ts-node test-e2e/simple/run.ts",
     "lint": "eslint .",

--- a/test/jestMatchers.test.ts
+++ b/test/jestMatchers.test.ts
@@ -193,6 +193,18 @@ Calls:
 `);
     });
 
+    it('fails on receiving less Commands than the nth requested', async () => {
+        const sns = new SNSClient({});
+        await sns.send(publishCmd1);
+
+        expect(() => expect(snsMock).toHaveReceivedNthCommandWith(2, PublishCommand, {Message: publishCmd2.input.Message})).toThrowErrorMatchingInlineSnapshot(`
+"Expected SNSClient to receive 2. <green>\\"PublishCommand\\"</> with <green>{\\"Message\\": \\"second mock message\\"}</>
+
+Calls:
+  1. PublishCommand: <red>{\\"Message\\": \\"mock message\\", \\"TopicArn\\": \\"arn:aws:sns:us-east-1:111111111111:MyTopic\\"}</>"
+`);
+    });
+
     it('passes on match with asymmetric matcher', async () => {
         const sns = new SNSClient({});
         await sns.send(publishCmd1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8218,7 +8218,7 @@ prettier-bytes@^1.0.4:
   resolved "https://registry.yarnpkg.com/prettier-bytes/-/prettier-bytes-1.0.4.tgz#994b02aa46f699c50b6257b5faaa7fe2557e62d6"
   integrity sha1-mUsCqkb2mcULYle1+qp/4lV+YtY=
 
-pretty-format@^28.0.0, pretty-format@^28.1.1:
+pretty-format@28.1.1, pretty-format@^28.0.0, pretty-format@^28.1.1:
   version "28.1.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.1.tgz#f731530394e0f7fcd95aba6b43c50e02d86b95cb"
   integrity sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==


### PR DESCRIPTION
Adds support for asymmetric Jest matchers like `expect.stringMatching` in custom Jest matchers.

Example:

```ts
expect(snsMock).toHaveReceivedCommandWith(PublishCommand, {
    Message: expect.stringMatching(/message/)
});
```

Fixes #98 