### PR TITLE
docs: add further instructions on using Jest matchers outside of Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,14 @@ Shorter aliases exist, like `toReceiveCommandTimes()`.
 To use those matchers with [Vitest](https://vitest.dev/), set `test.globals` to `true` in `vite.config.js`
 (see [#139](https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139)).
 
+To use the matchers outside of Jest, you can pull in the "[expect](https://www.npmjs.com/package/expect)" library separately. To use them in Typescript or ES6 modules, you may need to add `expect` to global scope directly, e.g.
+
+```ts
+const {expect} = require("expect");
+(globalThis as any).expect = expect;
+require("aws-sdk-client-mock-jest");
+```
+
 ## API Reference
 
 See the [full API Reference](https://m-radzikowski.github.io/aws-sdk-client-mock/).

--- a/README.md
+++ b/README.md
@@ -474,7 +474,8 @@ Shorter aliases exist, like `toReceiveCommandTimes()`.
 To use those matchers with [Vitest](https://vitest.dev/), set `test.globals` to `true` in `vite.config.js`
 (see [#139](https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139)).
 
-To use the matchers outside of Jest, you can pull in the "[expect](https://www.npmjs.com/package/expect)" library separately. To use them in Typescript or ES6 modules, you may need to add `expect` to global scope directly, e.g.
+To use the matchers outside of Jest, you can pull in the [expect](https://www.npmjs.com/package/expect) library separately
+and add it to the global scope directly, e.g.:
 
 ```ts
 const {expect} = require("expect");


### PR DESCRIPTION
It took me a very long time to get this working, so I wanted to add instructions to other users who may have the same problems.

I'm not 100% sure I understand modules vs require in Node (despite working with Node for quite a long time now), so perhaps these instructions are not optimal, but they work for me when nothing else did. I'm using node 18 with Typescript via "esbuild".

Thanks for your work on `aws-sdk-client-mock`