### PR TITLE
docs: callsFake chaining example

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,20 @@ snsMock
     });
 ```
 
+Specify custom mock function for a specific command (chained behavior):
+
+```typescript
+snsMock
+    .on(PublishCommand)
+    .callsFake(input => {
+        if (input.Message === 'My message') {
+            return {MessageId: '12345678-1111-2222-3333-111122223333'};
+        } else {
+            throw new Error('mocked rejection');
+        }
+    });
+```
+
 Together with `resolvesOnce()`, you can also use `rejectsOnce()` and `callsFakeOnce()`
 to specify consecutive behaviors.
 


### PR DESCRIPTION
Provide an example demonstrating that `callsFake` can be chained, so that you can you can mock the implementation of specific commands.