### PR TITLE
Update Smithy types to 3.0.0 and AWS SDK to 3.577.0

### DIFF
--- a/packages/aws-sdk-client-mock-jest/package.json
+++ b/packages/aws-sdk-client-mock-jest/package.json
@@ -44,9 +44,9 @@
     "tslib": "^2.1.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-sns": "3.363.0",
+    "@aws-sdk/client-sns": "3.577.0",
     "@jest/globals": "29.7.0",
-    "@smithy/types": "1.1.0",
+    "@smithy/types": "3.0.0",
     "@types/jest": "29.5.11",
     "aws-sdk-client-mock": "workspace:*",
     "expect": "29.7.0",

--- a/packages/aws-sdk-client-mock/package.json
+++ b/packages/aws-sdk-client-mock/package.json
@@ -44,13 +44,13 @@
     "tslib": "^2.1.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "3.363.0",
-    "@aws-sdk/client-s3": "3.363.0",
-    "@aws-sdk/client-sns": "3.363.0",
-    "@aws-sdk/client-sqs": "3.363.0",
-    "@aws-sdk/lib-dynamodb": "3.363.0",
-    "@smithy/types": "1.1.0",
-    "typedoc": "0.23.26"
+    "@aws-sdk/client-dynamodb": "3.577.0",
+    "@aws-sdk/client-s3": "3.577.0",
+    "@aws-sdk/client-sns": "3.577.0",
+    "@aws-sdk/client-sqs": "3.577.0",
+    "@aws-sdk/lib-dynamodb": "3.577.0",
+    "@smithy/types": "3.0.0",
+    "typedoc": "0.25.13"
   },
   "jest": {
     "preset": "ts-jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,708 +108,743 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/chunked-blob-reader@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/chunked-blob-reader@npm:3.310.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 4969fe05c6cea38d0a8dc3ec8e37cbd82a0a5b6f8c32ad6c7d02f0800bc3641e96356f47981c88b645b4dc2bdcb73d03d7ec67ac38d277dde8337b61688f815b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-dynamodb@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/client-dynamodb@npm:3.363.0"
+"@aws-sdk/client-dynamodb@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/client-dynamodb@npm:3.577.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.363.0
-    "@aws-sdk/credential-provider-node": 3.363.0
-    "@aws-sdk/middleware-endpoint-discovery": 3.363.0
-    "@aws-sdk/middleware-host-header": 3.363.0
-    "@aws-sdk/middleware-logger": 3.363.0
-    "@aws-sdk/middleware-recursion-detection": 3.363.0
-    "@aws-sdk/middleware-signing": 3.363.0
-    "@aws-sdk/middleware-user-agent": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.363.0
-    "@aws-sdk/util-user-agent-node": 3.363.0
-    "@smithy/config-resolver": ^1.0.1
-    "@smithy/fetch-http-handler": ^1.0.1
-    "@smithy/hash-node": ^1.0.1
-    "@smithy/invalid-dependency": ^1.0.1
-    "@smithy/middleware-content-length": ^1.0.1
-    "@smithy/middleware-endpoint": ^1.0.1
-    "@smithy/middleware-retry": ^1.0.2
-    "@smithy/middleware-serde": ^1.0.1
-    "@smithy/middleware-stack": ^1.0.1
-    "@smithy/node-config-provider": ^1.0.1
-    "@smithy/node-http-handler": ^1.0.2
-    "@smithy/protocol-http": ^1.0.1
-    "@smithy/smithy-client": ^1.0.3
-    "@smithy/types": ^1.0.0
-    "@smithy/url-parser": ^1.0.1
-    "@smithy/util-base64": ^1.0.1
-    "@smithy/util-body-length-browser": ^1.0.1
-    "@smithy/util-body-length-node": ^1.0.1
-    "@smithy/util-defaults-mode-browser": ^1.0.1
-    "@smithy/util-defaults-mode-node": ^1.0.1
-    "@smithy/util-retry": ^1.0.2
-    "@smithy/util-utf8": ^1.0.1
-    "@smithy/util-waiter": ^1.0.1
-    tslib: ^2.5.0
-    uuid: ^8.3.2
-  checksum: cbcf61d58be115e598b1c0a48a4197adb8e92b77b70fa8c922855afe0b6d68bd9613013f477c25daeb2be24ea5dfaf8c05394138d65d15282516fc3806098cdc
+    "@aws-sdk/client-sso-oidc": 3.577.0
+    "@aws-sdk/client-sts": 3.577.0
+    "@aws-sdk/core": 3.576.0
+    "@aws-sdk/credential-provider-node": 3.577.0
+    "@aws-sdk/middleware-endpoint-discovery": 3.577.0
+    "@aws-sdk/middleware-host-header": 3.577.0
+    "@aws-sdk/middleware-logger": 3.577.0
+    "@aws-sdk/middleware-recursion-detection": 3.577.0
+    "@aws-sdk/middleware-user-agent": 3.577.0
+    "@aws-sdk/region-config-resolver": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@aws-sdk/util-endpoints": 3.577.0
+    "@aws-sdk/util-user-agent-browser": 3.577.0
+    "@aws-sdk/util-user-agent-node": 3.577.0
+    "@smithy/config-resolver": ^3.0.0
+    "@smithy/core": ^2.0.0
+    "@smithy/fetch-http-handler": ^3.0.0
+    "@smithy/hash-node": ^3.0.0
+    "@smithy/invalid-dependency": ^3.0.0
+    "@smithy/middleware-content-length": ^3.0.0
+    "@smithy/middleware-endpoint": ^3.0.0
+    "@smithy/middleware-retry": ^3.0.0
+    "@smithy/middleware-serde": ^3.0.0
+    "@smithy/middleware-stack": ^3.0.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/url-parser": ^3.0.0
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.0
+    "@smithy/util-defaults-mode-node": ^3.0.0
+    "@smithy/util-endpoints": ^2.0.0
+    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-retry": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    "@smithy/util-waiter": ^3.0.0
+    tslib: ^2.6.2
+    uuid: ^9.0.1
+  checksum: 062fc834b77768bbb5a58d6d16de12a3288ef77ddafcda8d68be1fea8468f3cac30223a60c5f5c009c0f1b064cc29c6d2eee43bd35993c29b0cfd3fae8072990
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/client-s3@npm:3.363.0"
+"@aws-sdk/client-s3@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/client-s3@npm:3.577.0"
   dependencies:
     "@aws-crypto/sha1-browser": 3.0.0
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.363.0
-    "@aws-sdk/credential-provider-node": 3.363.0
-    "@aws-sdk/hash-blob-browser": 3.357.0
-    "@aws-sdk/hash-stream-node": 3.357.0
-    "@aws-sdk/md5-js": 3.357.0
-    "@aws-sdk/middleware-bucket-endpoint": 3.363.0
-    "@aws-sdk/middleware-expect-continue": 3.363.0
-    "@aws-sdk/middleware-flexible-checksums": 3.363.0
-    "@aws-sdk/middleware-host-header": 3.363.0
-    "@aws-sdk/middleware-location-constraint": 3.363.0
-    "@aws-sdk/middleware-logger": 3.363.0
-    "@aws-sdk/middleware-recursion-detection": 3.363.0
-    "@aws-sdk/middleware-sdk-s3": 3.363.0
-    "@aws-sdk/middleware-signing": 3.363.0
-    "@aws-sdk/middleware-ssec": 3.363.0
-    "@aws-sdk/middleware-user-agent": 3.363.0
-    "@aws-sdk/signature-v4-multi-region": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.363.0
-    "@aws-sdk/util-user-agent-node": 3.363.0
-    "@aws-sdk/xml-builder": 3.310.0
-    "@smithy/config-resolver": ^1.0.1
-    "@smithy/eventstream-serde-browser": ^1.0.1
-    "@smithy/eventstream-serde-config-resolver": ^1.0.1
-    "@smithy/eventstream-serde-node": ^1.0.1
-    "@smithy/fetch-http-handler": ^1.0.1
-    "@smithy/hash-node": ^1.0.1
-    "@smithy/invalid-dependency": ^1.0.1
-    "@smithy/middleware-content-length": ^1.0.1
-    "@smithy/middleware-endpoint": ^1.0.1
-    "@smithy/middleware-retry": ^1.0.2
-    "@smithy/middleware-serde": ^1.0.1
-    "@smithy/middleware-stack": ^1.0.1
-    "@smithy/node-config-provider": ^1.0.1
-    "@smithy/node-http-handler": ^1.0.2
-    "@smithy/protocol-http": ^1.0.1
-    "@smithy/smithy-client": ^1.0.3
-    "@smithy/types": ^1.0.0
-    "@smithy/url-parser": ^1.0.1
-    "@smithy/util-base64": ^1.0.1
-    "@smithy/util-body-length-browser": ^1.0.1
-    "@smithy/util-body-length-node": ^1.0.1
-    "@smithy/util-defaults-mode-browser": ^1.0.1
-    "@smithy/util-defaults-mode-node": ^1.0.1
-    "@smithy/util-retry": ^1.0.2
-    "@smithy/util-stream": ^1.0.1
-    "@smithy/util-utf8": ^1.0.1
-    "@smithy/util-waiter": ^1.0.1
+    "@aws-sdk/client-sso-oidc": 3.577.0
+    "@aws-sdk/client-sts": 3.577.0
+    "@aws-sdk/core": 3.576.0
+    "@aws-sdk/credential-provider-node": 3.577.0
+    "@aws-sdk/middleware-bucket-endpoint": 3.577.0
+    "@aws-sdk/middleware-expect-continue": 3.577.0
+    "@aws-sdk/middleware-flexible-checksums": 3.577.0
+    "@aws-sdk/middleware-host-header": 3.577.0
+    "@aws-sdk/middleware-location-constraint": 3.577.0
+    "@aws-sdk/middleware-logger": 3.577.0
+    "@aws-sdk/middleware-recursion-detection": 3.577.0
+    "@aws-sdk/middleware-sdk-s3": 3.577.0
+    "@aws-sdk/middleware-signing": 3.577.0
+    "@aws-sdk/middleware-ssec": 3.577.0
+    "@aws-sdk/middleware-user-agent": 3.577.0
+    "@aws-sdk/region-config-resolver": 3.577.0
+    "@aws-sdk/signature-v4-multi-region": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@aws-sdk/util-endpoints": 3.577.0
+    "@aws-sdk/util-user-agent-browser": 3.577.0
+    "@aws-sdk/util-user-agent-node": 3.577.0
+    "@aws-sdk/xml-builder": 3.575.0
+    "@smithy/config-resolver": ^3.0.0
+    "@smithy/core": ^2.0.0
+    "@smithy/eventstream-serde-browser": ^3.0.0
+    "@smithy/eventstream-serde-config-resolver": ^3.0.0
+    "@smithy/eventstream-serde-node": ^3.0.0
+    "@smithy/fetch-http-handler": ^3.0.0
+    "@smithy/hash-blob-browser": ^3.0.0
+    "@smithy/hash-node": ^3.0.0
+    "@smithy/hash-stream-node": ^3.0.0
+    "@smithy/invalid-dependency": ^3.0.0
+    "@smithy/md5-js": ^3.0.0
+    "@smithy/middleware-content-length": ^3.0.0
+    "@smithy/middleware-endpoint": ^3.0.0
+    "@smithy/middleware-retry": ^3.0.0
+    "@smithy/middleware-serde": ^3.0.0
+    "@smithy/middleware-stack": ^3.0.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/url-parser": ^3.0.0
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.0
+    "@smithy/util-defaults-mode-node": ^3.0.0
+    "@smithy/util-endpoints": ^2.0.0
+    "@smithy/util-retry": ^3.0.0
+    "@smithy/util-stream": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    "@smithy/util-waiter": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 0c85fd30211e562ddb4cccb7eb8204b1a3b8727e9c5c763faf05968493e9b12b27a0644d2aafa6b7d7d1b80e2f1c226be931d60c1e4aeded52066682a409bfe9
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sns@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/client-sns@npm:3.577.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sso-oidc": 3.577.0
+    "@aws-sdk/client-sts": 3.577.0
+    "@aws-sdk/core": 3.576.0
+    "@aws-sdk/credential-provider-node": 3.577.0
+    "@aws-sdk/middleware-host-header": 3.577.0
+    "@aws-sdk/middleware-logger": 3.577.0
+    "@aws-sdk/middleware-recursion-detection": 3.577.0
+    "@aws-sdk/middleware-user-agent": 3.577.0
+    "@aws-sdk/region-config-resolver": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@aws-sdk/util-endpoints": 3.577.0
+    "@aws-sdk/util-user-agent-browser": 3.577.0
+    "@aws-sdk/util-user-agent-node": 3.577.0
+    "@smithy/config-resolver": ^3.0.0
+    "@smithy/core": ^2.0.0
+    "@smithy/fetch-http-handler": ^3.0.0
+    "@smithy/hash-node": ^3.0.0
+    "@smithy/invalid-dependency": ^3.0.0
+    "@smithy/middleware-content-length": ^3.0.0
+    "@smithy/middleware-endpoint": ^3.0.0
+    "@smithy/middleware-retry": ^3.0.0
+    "@smithy/middleware-serde": ^3.0.0
+    "@smithy/middleware-stack": ^3.0.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/url-parser": ^3.0.0
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.0
+    "@smithy/util-defaults-mode-node": ^3.0.0
+    "@smithy/util-endpoints": ^2.0.0
+    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-retry": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: ddaf4fd94afd7562e048328729249544985e7bc94121b36d13149faf1969c61393ea30f55b17ac672b8abca7da8a15a8cfac2a297afdade221d7b5fd3c6cc6c1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sqs@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/client-sqs@npm:3.577.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sso-oidc": 3.577.0
+    "@aws-sdk/client-sts": 3.577.0
+    "@aws-sdk/core": 3.576.0
+    "@aws-sdk/credential-provider-node": 3.577.0
+    "@aws-sdk/middleware-host-header": 3.577.0
+    "@aws-sdk/middleware-logger": 3.577.0
+    "@aws-sdk/middleware-recursion-detection": 3.577.0
+    "@aws-sdk/middleware-sdk-sqs": 3.577.0
+    "@aws-sdk/middleware-user-agent": 3.577.0
+    "@aws-sdk/region-config-resolver": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@aws-sdk/util-endpoints": 3.577.0
+    "@aws-sdk/util-user-agent-browser": 3.577.0
+    "@aws-sdk/util-user-agent-node": 3.577.0
+    "@smithy/config-resolver": ^3.0.0
+    "@smithy/core": ^2.0.0
+    "@smithy/fetch-http-handler": ^3.0.0
+    "@smithy/hash-node": ^3.0.0
+    "@smithy/invalid-dependency": ^3.0.0
+    "@smithy/md5-js": ^3.0.0
+    "@smithy/middleware-content-length": ^3.0.0
+    "@smithy/middleware-endpoint": ^3.0.0
+    "@smithy/middleware-retry": ^3.0.0
+    "@smithy/middleware-serde": ^3.0.0
+    "@smithy/middleware-stack": ^3.0.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/url-parser": ^3.0.0
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.0
+    "@smithy/util-defaults-mode-node": ^3.0.0
+    "@smithy/util-endpoints": ^2.0.0
+    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-retry": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 0e3238e20d05be89cbd41f9039f2ff24e383963832d6c00fbd0d75613e17ea38a588e621406bc09bf766b719be64eff000849cc8e93463ba743addfd91a7c789
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso-oidc@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.577.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.577.0
+    "@aws-sdk/core": 3.576.0
+    "@aws-sdk/credential-provider-node": 3.577.0
+    "@aws-sdk/middleware-host-header": 3.577.0
+    "@aws-sdk/middleware-logger": 3.577.0
+    "@aws-sdk/middleware-recursion-detection": 3.577.0
+    "@aws-sdk/middleware-user-agent": 3.577.0
+    "@aws-sdk/region-config-resolver": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@aws-sdk/util-endpoints": 3.577.0
+    "@aws-sdk/util-user-agent-browser": 3.577.0
+    "@aws-sdk/util-user-agent-node": 3.577.0
+    "@smithy/config-resolver": ^3.0.0
+    "@smithy/core": ^2.0.0
+    "@smithy/fetch-http-handler": ^3.0.0
+    "@smithy/hash-node": ^3.0.0
+    "@smithy/invalid-dependency": ^3.0.0
+    "@smithy/middleware-content-length": ^3.0.0
+    "@smithy/middleware-endpoint": ^3.0.0
+    "@smithy/middleware-retry": ^3.0.0
+    "@smithy/middleware-serde": ^3.0.0
+    "@smithy/middleware-stack": ^3.0.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/url-parser": ^3.0.0
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.0
+    "@smithy/util-defaults-mode-node": ^3.0.0
+    "@smithy/util-endpoints": ^2.0.0
+    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-retry": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 1c709c58e7104d3884339f0b3b97e9c1addb84081108658e3dfe3885c40b32043a30c891d1ce9d38fa40e1ed8625283cd0afc443e6f6f47ff5f3ff1614a51109
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/client-sso@npm:3.577.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/core": 3.576.0
+    "@aws-sdk/middleware-host-header": 3.577.0
+    "@aws-sdk/middleware-logger": 3.577.0
+    "@aws-sdk/middleware-recursion-detection": 3.577.0
+    "@aws-sdk/middleware-user-agent": 3.577.0
+    "@aws-sdk/region-config-resolver": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@aws-sdk/util-endpoints": 3.577.0
+    "@aws-sdk/util-user-agent-browser": 3.577.0
+    "@aws-sdk/util-user-agent-node": 3.577.0
+    "@smithy/config-resolver": ^3.0.0
+    "@smithy/core": ^2.0.0
+    "@smithy/fetch-http-handler": ^3.0.0
+    "@smithy/hash-node": ^3.0.0
+    "@smithy/invalid-dependency": ^3.0.0
+    "@smithy/middleware-content-length": ^3.0.0
+    "@smithy/middleware-endpoint": ^3.0.0
+    "@smithy/middleware-retry": ^3.0.0
+    "@smithy/middleware-serde": ^3.0.0
+    "@smithy/middleware-stack": ^3.0.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/url-parser": ^3.0.0
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.0
+    "@smithy/util-defaults-mode-node": ^3.0.0
+    "@smithy/util-endpoints": ^2.0.0
+    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-retry": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 5ecce3f6dbbef0722f22fac8ba6e4b43fac7ee33fa0906932205143eb1bf9b305a0b3e3d137d4c8b918cd5e3923f8be67c239c39deee3f54e42c4890859a5e0a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sts@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/client-sts@npm:3.577.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sso-oidc": 3.577.0
+    "@aws-sdk/core": 3.576.0
+    "@aws-sdk/credential-provider-node": 3.577.0
+    "@aws-sdk/middleware-host-header": 3.577.0
+    "@aws-sdk/middleware-logger": 3.577.0
+    "@aws-sdk/middleware-recursion-detection": 3.577.0
+    "@aws-sdk/middleware-user-agent": 3.577.0
+    "@aws-sdk/region-config-resolver": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@aws-sdk/util-endpoints": 3.577.0
+    "@aws-sdk/util-user-agent-browser": 3.577.0
+    "@aws-sdk/util-user-agent-node": 3.577.0
+    "@smithy/config-resolver": ^3.0.0
+    "@smithy/core": ^2.0.0
+    "@smithy/fetch-http-handler": ^3.0.0
+    "@smithy/hash-node": ^3.0.0
+    "@smithy/invalid-dependency": ^3.0.0
+    "@smithy/middleware-content-length": ^3.0.0
+    "@smithy/middleware-endpoint": ^3.0.0
+    "@smithy/middleware-retry": ^3.0.0
+    "@smithy/middleware-serde": ^3.0.0
+    "@smithy/middleware-stack": ^3.0.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/url-parser": ^3.0.0
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.0
+    "@smithy/util-defaults-mode-node": ^3.0.0
+    "@smithy/util-endpoints": ^2.0.0
+    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-retry": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 040754777487ac0e8d2a36b717ef32358c2989de144cd594be1b93dc9801f111a3edd36447d3fce103c78c95c8116d5cd90822876f0225259705559f94f8f54f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/core@npm:3.576.0":
+  version: 3.576.0
+  resolution: "@aws-sdk/core@npm:3.576.0"
+  dependencies:
+    "@smithy/core": ^2.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/signature-v4": ^3.0.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
     fast-xml-parser: 4.2.5
-    tslib: ^2.5.0
-  checksum: 35557dd4b9bdd00178e0fc66d14c99380feac1e0be7af0c24533ede292f22fbd6dbc4fd33af9bfc0a01a219c075fe9346fa07fed30476d1f5749a4f7122bb095
+    tslib: ^2.6.2
+  checksum: c9a6e3f71fb1a7319137feba876800da3f3ecae6ecb467b999a22dba165b0ab57c32b4f32f9c8213f5fedd57e4a733cd5a6701d38ac68e7181bddb530fe4b085
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sns@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/client-sns@npm:3.363.0"
+"@aws-sdk/credential-provider-env@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.577.0"
   dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.363.0
-    "@aws-sdk/credential-provider-node": 3.363.0
-    "@aws-sdk/middleware-host-header": 3.363.0
-    "@aws-sdk/middleware-logger": 3.363.0
-    "@aws-sdk/middleware-recursion-detection": 3.363.0
-    "@aws-sdk/middleware-signing": 3.363.0
-    "@aws-sdk/middleware-user-agent": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.363.0
-    "@aws-sdk/util-user-agent-node": 3.363.0
-    "@smithy/config-resolver": ^1.0.1
-    "@smithy/fetch-http-handler": ^1.0.1
-    "@smithy/hash-node": ^1.0.1
-    "@smithy/invalid-dependency": ^1.0.1
-    "@smithy/middleware-content-length": ^1.0.1
-    "@smithy/middleware-endpoint": ^1.0.1
-    "@smithy/middleware-retry": ^1.0.2
-    "@smithy/middleware-serde": ^1.0.1
-    "@smithy/middleware-stack": ^1.0.1
-    "@smithy/node-config-provider": ^1.0.1
-    "@smithy/node-http-handler": ^1.0.2
-    "@smithy/protocol-http": ^1.0.1
-    "@smithy/smithy-client": ^1.0.3
-    "@smithy/types": ^1.0.0
-    "@smithy/url-parser": ^1.0.1
-    "@smithy/util-base64": ^1.0.1
-    "@smithy/util-body-length-browser": ^1.0.1
-    "@smithy/util-body-length-node": ^1.0.1
-    "@smithy/util-defaults-mode-browser": ^1.0.1
-    "@smithy/util-defaults-mode-node": ^1.0.1
-    "@smithy/util-retry": ^1.0.2
-    "@smithy/util-utf8": ^1.0.1
-    fast-xml-parser: 4.2.5
-    tslib: ^2.5.0
-  checksum: 768a97ac50ea32f8608c9eb6cd1d3a9f49e7eceafd6d2833422cd20867f2711788d6d742d1544c6cff3f8b9d596ff58714f32ed57c86e91dda77ab29fa590368
+    "@aws-sdk/types": 3.577.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 155de3eafccc3eac6b94d53b4ec89b8f7ea313866e245f04887c4b0b274bcc4d04c9a1bc0c1cb7ae238a99aa032bf9c4eab6c1b1b676a06cce0de233ca0a7884
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sqs@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/client-sqs@npm:3.363.0"
+"@aws-sdk/credential-provider-http@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.577.0"
   dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.363.0
-    "@aws-sdk/credential-provider-node": 3.363.0
-    "@aws-sdk/middleware-host-header": 3.363.0
-    "@aws-sdk/middleware-logger": 3.363.0
-    "@aws-sdk/middleware-recursion-detection": 3.363.0
-    "@aws-sdk/middleware-sdk-sqs": 3.363.0
-    "@aws-sdk/middleware-signing": 3.363.0
-    "@aws-sdk/middleware-user-agent": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.363.0
-    "@aws-sdk/util-user-agent-node": 3.363.0
-    "@smithy/config-resolver": ^1.0.1
-    "@smithy/fetch-http-handler": ^1.0.1
-    "@smithy/hash-node": ^1.0.1
-    "@smithy/invalid-dependency": ^1.0.1
-    "@smithy/md5-js": ^1.0.1
-    "@smithy/middleware-content-length": ^1.0.1
-    "@smithy/middleware-endpoint": ^1.0.1
-    "@smithy/middleware-retry": ^1.0.2
-    "@smithy/middleware-serde": ^1.0.1
-    "@smithy/middleware-stack": ^1.0.1
-    "@smithy/node-config-provider": ^1.0.1
-    "@smithy/node-http-handler": ^1.0.2
-    "@smithy/protocol-http": ^1.0.1
-    "@smithy/smithy-client": ^1.0.3
-    "@smithy/types": ^1.0.0
-    "@smithy/url-parser": ^1.0.1
-    "@smithy/util-base64": ^1.0.1
-    "@smithy/util-body-length-browser": ^1.0.1
-    "@smithy/util-body-length-node": ^1.0.1
-    "@smithy/util-defaults-mode-browser": ^1.0.1
-    "@smithy/util-defaults-mode-node": ^1.0.1
-    "@smithy/util-retry": ^1.0.2
-    "@smithy/util-utf8": ^1.0.1
-    fast-xml-parser: 4.2.5
-    tslib: ^2.5.0
-  checksum: aa00d22cbb64ed8bcdc9509df2fb232246d09e64eaa1d9c298477c8f779574cce73b72e4ce20624ccbf835a92d387737504b346477dadf8f87c60447943f7371
+    "@aws-sdk/types": 3.577.0
+    "@smithy/fetch-http-handler": ^3.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-stream": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 8d5fbaaa30c093aa1e148c27d771239067009fd33bddc43e1e3442f3e7e3c70f1074f8f950bf9b660b179abbb5b21437fb5ff0fb3286afd5d470c4de25f5bff6
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso-oidc@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/client-sso-oidc@npm:3.363.0"
+"@aws-sdk/credential-provider-ini@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.577.0"
   dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/middleware-host-header": 3.363.0
-    "@aws-sdk/middleware-logger": 3.363.0
-    "@aws-sdk/middleware-recursion-detection": 3.363.0
-    "@aws-sdk/middleware-user-agent": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.363.0
-    "@aws-sdk/util-user-agent-node": 3.363.0
-    "@smithy/config-resolver": ^1.0.1
-    "@smithy/fetch-http-handler": ^1.0.1
-    "@smithy/hash-node": ^1.0.1
-    "@smithy/invalid-dependency": ^1.0.1
-    "@smithy/middleware-content-length": ^1.0.1
-    "@smithy/middleware-endpoint": ^1.0.1
-    "@smithy/middleware-retry": ^1.0.2
-    "@smithy/middleware-serde": ^1.0.1
-    "@smithy/middleware-stack": ^1.0.1
-    "@smithy/node-config-provider": ^1.0.1
-    "@smithy/node-http-handler": ^1.0.2
-    "@smithy/protocol-http": ^1.0.1
-    "@smithy/smithy-client": ^1.0.3
-    "@smithy/types": ^1.0.0
-    "@smithy/url-parser": ^1.0.1
-    "@smithy/util-base64": ^1.0.1
-    "@smithy/util-body-length-browser": ^1.0.1
-    "@smithy/util-body-length-node": ^1.0.1
-    "@smithy/util-defaults-mode-browser": ^1.0.1
-    "@smithy/util-defaults-mode-node": ^1.0.1
-    "@smithy/util-retry": ^1.0.2
-    "@smithy/util-utf8": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 89c24c9bc083c6995370fdbd68f4933dd0c90bdbc62f5c7dd1cd3b07b13195c3ab9abf25e2657e725b2330ec99fcc69b9e1392565c3e34f8e6cd7164b115a335
+    "@aws-sdk/credential-provider-env": 3.577.0
+    "@aws-sdk/credential-provider-process": 3.577.0
+    "@aws-sdk/credential-provider-sso": 3.577.0
+    "@aws-sdk/credential-provider-web-identity": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@smithy/credential-provider-imds": ^3.0.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/shared-ini-file-loader": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  peerDependencies:
+    "@aws-sdk/client-sts": ^3.577.0
+  checksum: 144b8713545d2766e08cede47c0bda9c20dd5744ad3679089f1ac1786fcd7f319f02faebe6af9649dfc5da4bd74ea8cfddce90c96fae776abf878b57058c4045
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/client-sso@npm:3.363.0"
+"@aws-sdk/credential-provider-node@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.577.0"
   dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/middleware-host-header": 3.363.0
-    "@aws-sdk/middleware-logger": 3.363.0
-    "@aws-sdk/middleware-recursion-detection": 3.363.0
-    "@aws-sdk/middleware-user-agent": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.363.0
-    "@aws-sdk/util-user-agent-node": 3.363.0
-    "@smithy/config-resolver": ^1.0.1
-    "@smithy/fetch-http-handler": ^1.0.1
-    "@smithy/hash-node": ^1.0.1
-    "@smithy/invalid-dependency": ^1.0.1
-    "@smithy/middleware-content-length": ^1.0.1
-    "@smithy/middleware-endpoint": ^1.0.1
-    "@smithy/middleware-retry": ^1.0.2
-    "@smithy/middleware-serde": ^1.0.1
-    "@smithy/middleware-stack": ^1.0.1
-    "@smithy/node-config-provider": ^1.0.1
-    "@smithy/node-http-handler": ^1.0.2
-    "@smithy/protocol-http": ^1.0.1
-    "@smithy/smithy-client": ^1.0.3
-    "@smithy/types": ^1.0.0
-    "@smithy/url-parser": ^1.0.1
-    "@smithy/util-base64": ^1.0.1
-    "@smithy/util-body-length-browser": ^1.0.1
-    "@smithy/util-body-length-node": ^1.0.1
-    "@smithy/util-defaults-mode-browser": ^1.0.1
-    "@smithy/util-defaults-mode-node": ^1.0.1
-    "@smithy/util-retry": ^1.0.2
-    "@smithy/util-utf8": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 938f435f25125458920aad3c7e6d6964df49b42ad447de19b60fe212de9cc1c638d6e8cff224cf49a0a973ecb69e2eb8360415138ad985d614f35c9af13d3457
+    "@aws-sdk/credential-provider-env": 3.577.0
+    "@aws-sdk/credential-provider-http": 3.577.0
+    "@aws-sdk/credential-provider-ini": 3.577.0
+    "@aws-sdk/credential-provider-process": 3.577.0
+    "@aws-sdk/credential-provider-sso": 3.577.0
+    "@aws-sdk/credential-provider-web-identity": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@smithy/credential-provider-imds": ^3.0.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/shared-ini-file-loader": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 572de7b6703725273b21010fd5a9e1306d160eea1717144856e80bed8bf8beadc20d015a7581d6d040d1e156c7942782aaade24423f31fecaec3d7a96876f4bb
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/client-sts@npm:3.363.0"
+"@aws-sdk/credential-provider-process@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.577.0"
   dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/credential-provider-node": 3.363.0
-    "@aws-sdk/middleware-host-header": 3.363.0
-    "@aws-sdk/middleware-logger": 3.363.0
-    "@aws-sdk/middleware-recursion-detection": 3.363.0
-    "@aws-sdk/middleware-sdk-sts": 3.363.0
-    "@aws-sdk/middleware-signing": 3.363.0
-    "@aws-sdk/middleware-user-agent": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.363.0
-    "@aws-sdk/util-user-agent-node": 3.363.0
-    "@smithy/config-resolver": ^1.0.1
-    "@smithy/fetch-http-handler": ^1.0.1
-    "@smithy/hash-node": ^1.0.1
-    "@smithy/invalid-dependency": ^1.0.1
-    "@smithy/middleware-content-length": ^1.0.1
-    "@smithy/middleware-endpoint": ^1.0.1
-    "@smithy/middleware-retry": ^1.0.1
-    "@smithy/middleware-serde": ^1.0.1
-    "@smithy/middleware-stack": ^1.0.1
-    "@smithy/node-config-provider": ^1.0.1
-    "@smithy/node-http-handler": ^1.0.1
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/smithy-client": ^1.0.2
-    "@smithy/types": ^1.1.0
-    "@smithy/url-parser": ^1.0.1
-    "@smithy/util-base64": ^1.0.1
-    "@smithy/util-body-length-browser": ^1.0.1
-    "@smithy/util-body-length-node": ^1.0.1
-    "@smithy/util-defaults-mode-browser": ^1.0.1
-    "@smithy/util-defaults-mode-node": ^1.0.1
-    "@smithy/util-retry": ^1.0.1
-    "@smithy/util-utf8": ^1.0.1
-    fast-xml-parser: 4.2.5
-    tslib: ^2.5.0
-  checksum: 5af409a69d61a50b50fe0f73d69a85ef84ee23c4b9987f1c8f81b3b516fb0bdae99814ef011d96f8985e5895f563592f8ebb22d10a8d06bb937434387178487f
+    "@aws-sdk/types": 3.577.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/shared-ini-file-loader": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: aa97aac3407efcd3b72dd3bbd4d38daa158423bce454f93c62fc60b5c9c2cf2077ffe5c58a90d1690559d10731c6dfcac1d9cbcb8286a84d267f2ff7c7d926f4
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.363.0"
+"@aws-sdk/credential-provider-sso@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 760cd1090b9523f03058973fa4abde09ea71e012ffb1f71234ca059e4c4ab657d12fb688cb5e017f612278e95a3e9043b3a26b7aa86473aa2b915034ba71fa28
+    "@aws-sdk/client-sso": 3.577.0
+    "@aws-sdk/token-providers": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/shared-ini-file-loader": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 6bab0d779f3289316c5369995dbb04cb9955a655e5bec555c4d6012db30d73f7121b5963c1bac55759d28300e0defee562fdeeca24b6a95862a58e037fbf45ad
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.363.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.577.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.363.0
-    "@aws-sdk/credential-provider-process": 3.363.0
-    "@aws-sdk/credential-provider-sso": 3.363.0
-    "@aws-sdk/credential-provider-web-identity": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@smithy/credential-provider-imds": ^1.0.1
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/shared-ini-file-loader": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 6a23678a4e5f7ec78f2330005bd51efd0658cd24543ea32f7a54b090a3513f50d26f7ee52c4da3eb748c3be1e199adcfc4e5a2e6d2dfc85b64ab9b3aa5825db4
+    "@aws-sdk/types": 3.577.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  peerDependencies:
+    "@aws-sdk/client-sts": ^3.577.0
+  checksum: d3eb6c99fe2bfae457c8122b155d0608f0cb0c8fd4bc067f587ffced795b61e4709256842ea629abc0849a085b26d1a946711a646dd87394da6b4d31db7f07e6
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.363.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.363.0
-    "@aws-sdk/credential-provider-ini": 3.363.0
-    "@aws-sdk/credential-provider-process": 3.363.0
-    "@aws-sdk/credential-provider-sso": 3.363.0
-    "@aws-sdk/credential-provider-web-identity": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@smithy/credential-provider-imds": ^1.0.1
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/shared-ini-file-loader": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 9a50f8ec1713be3ebd14c233d4e97c149277004ac91b14110497d572942d8c7a48d5201277defd077bb6c2a0ca17db076bb4cf2b88fc343e186867b8cb177070
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-process@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.363.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/shared-ini-file-loader": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: d8f12f30a442f68f4d465ba38ea2dbb6e5df07da389ba9dc3a6178a2b125e50b62526d92af4fe3d18d38a74fdd00b97082dd2ad796bde9247aa014fa3229ca56
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-sso@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.363.0"
-  dependencies:
-    "@aws-sdk/client-sso": 3.363.0
-    "@aws-sdk/token-providers": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/shared-ini-file-loader": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 0cf8b29865e80ecc7f4aa02de389e9f313df40035eade19dfe6c3de4c3dd5b8a604cd9089b5ce3d0338fac2c9fcfe97da16becb51a9068d01c189dfa1e24b478
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-web-identity@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.363.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: b0625bf4e59b64f6d2cfb718db78d43e2ad25e4df1c2d5c9b662d43b25e4cda3409176ccabee586cd22362e39bfeafe089592c895c9bcb7b1d5e86db55c06826
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/endpoint-cache@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/endpoint-cache@npm:3.310.0"
+"@aws-sdk/endpoint-cache@npm:3.572.0":
+  version: 3.572.0
+  resolution: "@aws-sdk/endpoint-cache@npm:3.572.0"
   dependencies:
     mnemonist: 0.38.3
-    tslib: ^2.5.0
-  checksum: b90a5cfb66fd34b54198d4c10083bbaf8208e55ca02f7e8b14a7de0b2ad5d9dbdd3b38cc50173e5a86d34885f9cffbbe3dcef234fccc98f07920fd5a7f66b773
+    tslib: ^2.6.2
+  checksum: acaa8b0b608a64e4910d3f2c5b2022ef8a032388e9f807a7b71ea53e3fafe6f4d8df937f32f83c9d26d30b29fe23e91e6cafabaa57a64bfe3a10c07daa3c93e1
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-blob-browser@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/hash-blob-browser@npm:3.357.0"
+"@aws-sdk/lib-dynamodb@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/lib-dynamodb@npm:3.577.0"
   dependencies:
-    "@aws-sdk/chunked-blob-reader": 3.310.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 3bdc8b401b19521dcb8365a1e33d88f005af6e7c930c83eb45460eafcc4639b9a3d54d44a97ad3941f795d420a8fa3b7cb3b3b25bb4a79d16257031cd894e40b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/hash-stream-node@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/hash-stream-node@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-utf8": 3.310.0
-    tslib: ^2.5.0
-  checksum: 6599d19353c1aaeeac49b1f5aee37fa4c0ff00c23518c782a51df375f661fa7c068e2d3a4ebfdd7fc94ceee0419054c7f0150a0c8754fca85c9e67f5dbfe36b4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/is-array-buffer@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/is-array-buffer@npm:3.310.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: ddd1536ad16e29186fb5055bc279cfe9790b7c32552e1ee21e31d4e410e1df297b06c94c6117f854ec368d29e60a231dd8cc77e5b604a6260e7602876fd047f8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/lib-dynamodb@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/lib-dynamodb@npm:3.363.0"
-  dependencies:
-    "@aws-sdk/util-dynamodb": 3.363.0
-    tslib: ^2.5.0
+    "@aws-sdk/util-dynamodb": 3.577.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
   peerDependencies:
-    "@aws-sdk/client-dynamodb": ^3.0.0
-    "@aws-sdk/types": ^3.0.0
-  checksum: 4dd2a0405886aaeeaaa30da5a2edb51106254e5830f1a8ab0633d7f72ca02f7820843045bdcc1239133091d4620d938969d08856a3f40be8053aa766fb54499a
+    "@aws-sdk/client-dynamodb": ^3.577.0
+  checksum: 2b3decd32d2d96e20cd6cf806c1a0665941eadd694e41d41aa410dd12187181ae918c339ac6adac36d6028087d7b722125a2912d3672a87894c7093e6384fd62
   languageName: node
   linkType: hard
 
-"@aws-sdk/md5-js@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/md5-js@npm:3.357.0"
+"@aws-sdk/middleware-bucket-endpoint@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-utf8": 3.310.0
-    tslib: ^2.5.0
-  checksum: 7ca7ea50ccbbb22a1eadccdafe6686260273638616e283867d0b52701b0486ca81ad3c134b56c14428bc44ed5aaa1033c3467aa7fb345d413ea178ee26e90ce2
+    "@aws-sdk/types": 3.577.0
+    "@aws-sdk/util-arn-parser": 3.568.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-config-provider": ^3.0.0
+    tslib: ^2.6.2
+  checksum: abda003c2877df595e10c2a052cae27f9531535a0d38d79c45e3b90f81d09ec4f992f4670a8379dcc9a40fb19dda8a13aa9c481c5bcc5bf70ee13023093fce3a
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-bucket-endpoint@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.363.0"
+"@aws-sdk/middleware-endpoint-discovery@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-endpoint-discovery@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-arn-parser": 3.310.0
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/types": ^1.1.0
-    "@smithy/util-config-provider": ^1.0.1
-    tslib: ^2.5.0
-  checksum: a087b168b3ecbf8ef6e9a4ce12e6ec12dbadd1f0ebd1b034e0ba9a955ed0d7d1f0ff1db8e2a97e309206a220736de31614ea58a5cd0719180853aec2251c16db
+    "@aws-sdk/endpoint-cache": 3.572.0
+    "@aws-sdk/types": 3.577.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 972e5bac720bcbe256098d207592c20600de6bbd01d4f052122399b6e86e25bb0f7c8135214fadde6f042134bccb5b468968c3099f78b7e0a05584ba61471751
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-endpoint-discovery@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-endpoint-discovery@npm:3.363.0"
+"@aws-sdk/middleware-expect-continue@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.577.0"
   dependencies:
-    "@aws-sdk/endpoint-cache": 3.310.0
-    "@aws-sdk/types": 3.357.0
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 82470e40eb8e318c203a90b6129cd6307f9e87ffd9a47bcf3b75813f317d572f68f6a8f28396db62912ac84f1c83a32303a52e3b69129e8032ca3f686fd89453
+    "@aws-sdk/types": 3.577.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 69da58bceed2f57f9eebd6e6eddecaccf775052123b59e225f74366856eac8815bcd51bb5a8007f63d48d2b70142a848459dc014d5487764d8f8d57e0f3674f8
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.363.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 82ee54c2dad9f9a01f1c5463988f0b59b51c81477d0267af40af18356434d74af9168aa9c196188877ca50b8c650f78b5c1c332aa2264a289723dbf912e81924
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-flexible-checksums@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.363.0"
+"@aws-sdk/middleware-flexible-checksums@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.577.0"
   dependencies:
     "@aws-crypto/crc32": 3.0.0
     "@aws-crypto/crc32c": 3.0.0
-    "@aws-sdk/types": 3.357.0
-    "@smithy/is-array-buffer": ^1.0.1
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/types": ^1.1.0
-    "@smithy/util-utf8": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 273d5d58e5651a8a58ad31763721f033d4db6998af70922791a6763bc2a139e3af7bfd3f236a013b758f16892ffa5aef27a676e7bdbd8a0e840f1596b924fd00
+    "@aws-sdk/types": 3.577.0
+    "@smithy/is-array-buffer": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 8da0542e0cb5fc3dadea9dd99593b54fe9934ab1c196b0e655a722ac9b1c237bb583ed74c16217e11f8330ac957098d5d49878666e38b790b89b59d71d8e789b
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.363.0"
+"@aws-sdk/middleware-host-header@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 80f747bacb0cedb7f56f38836869807c15a6bf0d791a26ab9e856e4bfce7f895d63847caa14ccc4bf461352db7312a3f3d771c48132870aa91eea22dcf4f7922
+    "@aws-sdk/types": 3.577.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: f325612558d8d56a13e0593a78a1807c55dac5913313ed53d0a09a1c4bc771976e74e1738bd46068adeea755c35f72b19c2f902ecad1ff1ae52290972cf9fe88
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-location-constraint@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.363.0"
+"@aws-sdk/middleware-location-constraint@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 53af61498e5358cab9d8ef3b4f33a10745fc9c39f748f4ea5d24fba8da6166c2005bc1e4ee646c1886e87fdfce9ed705a017f5260072b12f8be75b5328809bc3
+    "@aws-sdk/types": 3.577.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: d45fdd1e4e48784b6518205656e79c2c5520f69c09a3d4e0a80bc7f7357a910b3ce8ab1cd73379441eed2049340144a7435a249c7de6b197f5e8e9e8f0868ac2
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.363.0"
+"@aws-sdk/middleware-logger@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 13c6dccb41b7c5538bbb58367b6c5f6b9971509afded35fad1dc9bfe56be306eb1e8ad7e46bc8c6457a515880642073c66a2a3ec1f3f08a538089a9d5d6b9ecf
+    "@aws-sdk/types": 3.577.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 142e993c82997391fb9c66244f2add15ad71e626b9aacf36a81ea369d33e3a1375ece09dd6315bf8fcaf4d8dcbaae340237088f1091f12a8f56740eddb32090a
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-recursion-detection@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.363.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 7ef55ef6ca6fc3b4344502d40787e9c8bc21bfa8b86b5bb7087406af5d3a080038da42701a12777b4f636a5eeacfd73c6db020ee55527b24b5504c8d3ced54f7
+    "@aws-sdk/types": 3.577.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 9655fe7b9a071a9a62397871a7bc529ebfff372a2cd1997b78c22ff320b0cdf0224881c122375e0b97e7307a167d437f438f6c414db71c882afb66a0510a519e
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.363.0"
+"@aws-sdk/middleware-sdk-s3@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-arn-parser": 3.310.0
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 44f2c91be124d2445bb6f7b3ea3d81d02bae1dbe6f985ed870243c9bf33ef37bd4fcafaa46e07a89a9314f418254ce2f862d7def77d8ff42bcddc8685bf60cee
+    "@aws-sdk/types": 3.577.0
+    "@aws-sdk/util-arn-parser": 3.568.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/signature-v4": ^3.0.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-config-provider": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 04944e694ef4a0d04def540d263b11748a44d581b1199b818af1304108f5b6964a70d45a6824f6221f4c22c9115d7278df8875ce35083ebbdb6e64ce13848890
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sqs@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-sdk-sqs@npm:3.363.0"
+"@aws-sdk/middleware-sdk-sqs@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-sdk-sqs@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/types": ^1.1.0
-    "@smithy/util-hex-encoding": ^1.0.1
-    "@smithy/util-utf8": ^1.0.1
-    tslib: ^2.5.0
-  checksum: eef2e5643268c7d18acacb1b44748efe8184b8b24ec1e24823ccad807246eeb6780baf1873f6e7d09883c3a51463dc54db9e98c14a0c7765787969850cf9ba0c
+    "@aws-sdk/types": 3.577.0
+    "@smithy/smithy-client": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-hex-encoding": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 3679d4a2733ea781a65c28b07ff772c65ccdbdce24c4e2009e2d9b78cdf81d9674f8ade485105a76dd0851dad139eedd8ce414e7c9f7c59492286a22c11c1295
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sts@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.363.0"
+"@aws-sdk/middleware-signing@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.577.0"
   dependencies:
-    "@aws-sdk/middleware-signing": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: b5f03018e86b8b389ef1dc14a5e3078e95cd40a90490b0284b1933e65e4a15c8c27fad96f50ba82a605489b36c2092fbdaf6aaf7011ed2b07c5f3701d085517a
+    "@aws-sdk/types": 3.577.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/signature-v4": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-middleware": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 7709d0fb09cd2d7914a16d44f896a023e84d11ceef7c33a056e76aca5870da249f36a90bfb39d464dada0e8c669e9bba8194ec4c82fc1aaaae72963f11aa5bf6
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-signing@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.363.0"
+"@aws-sdk/middleware-ssec@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/signature-v4": ^1.0.1
-    "@smithy/types": ^1.1.0
-    "@smithy/util-middleware": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 7f4efb241b1d9241ffde3ac26b65eeee04c943fd68b0e83e72ce443b4821fb228bff7584b063cfcff62a35bac5f537460c4ef443b7a62fb3f8d6b1493bd36792
+    "@aws-sdk/types": 3.577.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 06dd8045727137184a9d3adff37126d73ec5af08dd4e086a764b9388ddd6389a6b92f9d8d4d5ea9a9790b5492951bbdef7c93252001c5135e75c2be74ea87241
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-ssec@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-ssec@npm:3.363.0"
+"@aws-sdk/middleware-user-agent@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 3a4db9cf5255d4536422861a918c2c802e0025e5f4be0dcd3a4ea15addb0c9b44842fdf774b42c13e554e33f3f70684d528a12db2cb29d34e0c9cd0b9a70cc3e
+    "@aws-sdk/types": 3.577.0
+    "@aws-sdk/util-endpoints": 3.577.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 0dcf215e0d9c3fef656d9709d6c207e0b3af06c1a037c4a2b7734f5f0a90103a0107883a0b7cf858b5b37ba1d50d7a4e13380390c8107fb6c4f54e567e548f33
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.363.0"
+"@aws-sdk/region-config-resolver@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: d66f0ec8030fbbbb200f30cc4564ee085333ffa4eded02502fadd561c4b3cb481e4bdc960369850696c89a54de592d1627ebb8f98b8f7aa84b03ff8b81f330b3
+    "@aws-sdk/types": 3.577.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-config-provider": ^3.0.0
+    "@smithy/util-middleware": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 66326254108ca87300bbb7aea7786da617293bb7fe093153eab123ff73a824071b1d3a155827bb9193925704e4f60d01cddfc71018d2e1a82d7609091338acfe
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4-multi-region@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.363.0"
+"@aws-sdk/signature-v4-multi-region@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/signature-v4": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
+    "@aws-sdk/middleware-sdk-s3": 3.577.0
+    "@aws-sdk/types": 3.577.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/signature-v4": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 19c75305b10eb11b64c93250c84acfbab1cf25ae19185d15adedef56a4da55df4fb2182a0c56c294c484dc17713b28aae42c869aea4434e064864bb9fa654a19
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/token-providers@npm:3.577.0"
+  dependencies:
+    "@aws-sdk/types": 3.577.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/shared-ini-file-loader": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
   peerDependencies:
-    "@aws-sdk/signature-v4-crt": ^3.118.0
-  peerDependenciesMeta:
-    "@aws-sdk/signature-v4-crt":
-      optional: true
-  checksum: 920328f0e8829ca7e91d2b1a096ef00c1722c15ff049eefe2f6b71f0d54401294bc15f746393ea23ef03847efc27293cb9920018ee68b6ead99ec5f0dd6353b7
+    "@aws-sdk/client-sso-oidc": ^3.577.0
+  checksum: e0437ed4af6d1b78d457a7c8abc8367e3c9134c678e945af776d3882175b6b0e73cfd9a49493da4e689aea51dd654ea58ab22fb88a336bb0cd29310dea4c90f2
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/token-providers@npm:3.363.0"
+"@aws-sdk/types@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/types@npm:3.577.0"
   dependencies:
-    "@aws-sdk/client-sso-oidc": 3.363.0
-    "@aws-sdk/types": 3.357.0
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/shared-ini-file-loader": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: ba945164da36a5d95fbd481702290489897097435014b2c3d22986c9e307000a63a0841798c2cbd59726ffe7dfbf0cc73c3d05a2064b679b164aef9bef00ec77
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: d10fe1d720adf3d8b17d5c23787611e336509569df7526efa96e8901100b9279a68e30a207eff60dc5cfa011abd68d47b81e40f2d4d1a9ddfd2d3653c20e1734
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.357.0, @aws-sdk/types@npm:^3.222.0":
+"@aws-sdk/types@npm:^3.222.0":
   version: 3.357.0
   resolution: "@aws-sdk/types@npm:3.357.0"
   dependencies:
@@ -818,41 +853,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-arn-parser@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-arn-parser@npm:3.310.0"
+"@aws-sdk/util-arn-parser@npm:3.568.0":
+  version: 3.568.0
+  resolution: "@aws-sdk/util-arn-parser@npm:3.568.0"
   dependencies:
-    tslib: ^2.5.0
-  checksum: faac1e10f8bb6c2fe5fee82bcb7ce56c2b37ae9ffdb2b78b0746a7a06005eaa5ea747a0a10eaf490c1c4907ecc327e1c94a600e26a069e023e54b8d63c031e96
+    tslib: ^2.6.2
+  checksum: e3c45e5d524a772954d0a33614d397414185b9eb635423d01253cad1c1b9add625798ed9cf23343d156fae89c701f484bc062ab673f67e2e2edfe362fde6d170
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-buffer-from@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-buffer-from@npm:3.310.0"
+"@aws-sdk/util-dynamodb@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/util-dynamodb@npm:3.577.0"
   dependencies:
-    "@aws-sdk/is-array-buffer": 3.310.0
-    tslib: ^2.5.0
-  checksum: 9c3bd9c0664a0cbb5270eb285a662274bb9c46ae0d79e0275a85e74659a4b1f094bab900994780fd70dd0152dc6d2d33a8bc681d87f3911fa48eae9f6c3558d6
+    tslib: ^2.6.2
+  peerDependencies:
+    "@aws-sdk/client-dynamodb": ^3.577.0
+  checksum: ae60276474bea1e84dc3e1efd65df8ec7cdf995fa22cb9d1dfbd13766d2808e1e642266c212fde4951e8f719af3113a193e20f1d2ce2da46e1b2643308cc6a5d
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-dynamodb@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/util-dynamodb@npm:3.363.0"
+"@aws-sdk/util-endpoints@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.577.0"
   dependencies:
-    tslib: ^2.5.0
-  checksum: 998d341fb7c16b5398d6adf270df75144b6c7fed0751c5493c7e5f75f2b3d44a3749dfb808876c0a26c92d5a704344238c7e7c5f0dd871908bfd7e349a859ca9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-endpoints@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: dcbe4a4ee0fe4490c64465c1dbaaf67d1da38fbc2e8d95e44f50dc4cc94c378b5d1e561c77d5d1c30bb89fb39891e24f1d3778dd8b1fda9305bc3529e3174fe5
+    "@aws-sdk/types": 3.577.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-endpoints": ^2.0.0
+    tslib: ^2.6.2
+  checksum: 7e70789b64a8980923bbb824638dcc838552b4b0d3ee7d67a62fa6e138e941b3b125adac861eebc3b789aee7d0a9487260bc7ea34d2b3126d81d83ce68e57aba
   languageName: node
   linkType: hard
 
@@ -865,32 +894,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.363.0"
+"@aws-sdk/util-user-agent-browser@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/types": ^1.1.0
+    "@aws-sdk/types": 3.577.0
+    "@smithy/types": ^3.0.0
     bowser: ^2.11.0
-    tslib: ^2.5.0
-  checksum: efd4319c2c6cf2385a471b28f0e48d6c197551a769040c5fe4e8fbcec0eb2b5f8fd326b17fefc3935d5bded731f1df5923fb114dc4ed720550731cfd0d2e597f
+    tslib: ^2.6.2
+  checksum: 48b29b186f9d59c7ee272568cb0752834527aeccf122e4794313f84fb4c72dc65edf4bbf22f07aa7e2dde7da288e6d7ba20633edd9dbc853aca1b170bdfe1532
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.363.0":
-  version: 3.363.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.363.0"
+"@aws-sdk/util-user-agent-node@npm:3.577.0":
+  version: 3.577.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.577.0"
   dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@smithy/node-config-provider": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
+    "@aws-sdk/types": 3.577.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: bfa6bdcfdfa10ae5beb1edf5ef4296b2f3f65ba48e897a601a2853be8b9d5a6510791eef9d3506ec1df261e2a88db10059a330d01d9b4fda83dc8d3766c735aa
+  checksum: 732fb562a02826fbe0e0ce2571c4f396b14515a57f01121e99b84088761f1cf6e47e03c9a3613e51f3ff34aae8eae3b47440e0e012a9f54096e7f2b244705ef5
   languageName: node
   linkType: hard
 
@@ -903,22 +932,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-utf8@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-utf8@npm:3.310.0"
+"@aws-sdk/xml-builder@npm:3.575.0":
+  version: 3.575.0
+  resolution: "@aws-sdk/xml-builder@npm:3.575.0"
   dependencies:
-    "@aws-sdk/util-buffer-from": 3.310.0
-    tslib: ^2.5.0
-  checksum: 4045e79b8e3593e12233b359ba77d1b4c162fd9fcb4ab3b58b711c41b725552306dd91402b8d57ce5be080c76309f046a7a0c4ff704d12f9ba71e3b25b810086
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/xml-builder@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/xml-builder@npm:3.310.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: fc17fd8f68470702d947948ada46097bdddecafdc68fa57bf584320e92748e8ef0372a51999d3ab7902ba4f62c2dbfbdec2dba1180fca19bb5127bad1ef0e48b
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 6b0542f5c05d666660ab63d9b9a2547d2b200751bd8e0d5b16d32d5c201eb237b4d1e25dbde7ac186d7c824664a0f638da9ecca6d76d34baff3c88e8349ef25f
   languageName: node
   linkType: hard
 
@@ -2260,484 +2280,567 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/abort-controller@npm:1.0.1"
+"@smithy/abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/abort-controller@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: f472dd24346915b71e61771920e86d603f30a7beb8a884652958029249d12c9c3a63820b2c9cf55b2626dc3c8f048faddd84b8b55789f3bdaf69e3c510975408
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 8ad1551b558d5cb14e60fdaf07663d37828d11e9bb0faccfa3622ee0b0ddd7c7eab97ae36f501fd3d5bdcb9c570ed4e9ed84cb7b4490053900d20399297f95b5
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/config-resolver@npm:1.0.1"
+"@smithy/chunked-blob-reader-native@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/chunked-blob-reader-native@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    "@smithy/util-config-provider": ^1.0.1
-    "@smithy/util-middleware": ^1.0.1
-    tslib: ^2.5.0
-  checksum: c0489bfd522f96b9a430e71c792ff3be9394a37a482b892a3f0784a7bfec8e36915bce17b62ff45f46d6236e8f530042294c1cb9d7de5e0eb431122529e19495
+    "@smithy/util-base64": ^3.0.0
+    tslib: ^2.6.2
+  checksum: f97c0c0ce5e9bd2350883df3c232311aa82eb87eb387125f685900326f86fc3aca208e9004291f742f6978abf91a0c1112cc9a803cd0caf0dffbcfa9b6d0239e
   languageName: node
   linkType: hard
 
-"@smithy/credential-provider-imds@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/credential-provider-imds@npm:1.0.1"
+"@smithy/chunked-blob-reader@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/chunked-blob-reader@npm:3.0.0"
   dependencies:
-    "@smithy/node-config-provider": ^1.0.1
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/types": ^1.1.0
-    "@smithy/url-parser": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 41bfa3e4728fff27290320638f2e26c34d49080505757430b2d66115debdac16aa329724f7b3008470f17aff75e92d456cad3d555d4562dc2bf7a5c17477ade4
+    tslib: ^2.6.2
+  checksum: 6f520884ade14f1073adb640db2f03eb22a9920f342f37958df3e98327890b741cd909b16cbbc6f70c6c8dd250d6b3a8d76841b685d4871b0403f309267def4f
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-codec@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/eventstream-codec@npm:1.0.1"
+"@smithy/config-resolver@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/config-resolver@npm:3.0.0"
+  dependencies:
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-config-provider": ^3.0.0
+    "@smithy/util-middleware": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 66d66e0c054e90e8dec61d1f8f774709f0e3d5227cec30221c27cc21fb51bbd691c0281f8f01bc4cc0a3472cb7776db3544260a45f8104b0ba1493c27ff2794b
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "@smithy/core@npm:2.0.1"
+  dependencies:
+    "@smithy/middleware-endpoint": ^3.0.0
+    "@smithy/middleware-retry": ^3.0.1
+    "@smithy/middleware-serde": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/smithy-client": ^3.0.1
+    "@smithy/types": ^3.0.0
+    "@smithy/util-middleware": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 6a02cfc67ea6f7eac367c41c7200c604bbd087a02c418aa69e1cc833b4f0693b1e28205eb62f516ca62ad4cac851a06f435ceaa4505f73b44f89790c11a1e889
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/credential-provider-imds@npm:3.0.0"
+  dependencies:
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/url-parser": ^3.0.0
+    tslib: ^2.6.2
+  checksum: f592303f6247ae3f404cc6dce108c69f88ffcc56d11fc219e16d101ec58b00141d6253c3f0bedb4a6cf4de5df9cea29514851647aa1a9d0ebe5865fdce37a7ca
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-codec@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-codec@npm:3.0.0"
   dependencies:
     "@aws-crypto/crc32": 3.0.0
-    "@smithy/types": ^1.1.0
-    "@smithy/util-hex-encoding": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 042e387582a542eabc5225a3ae5c19ba144d18e1673467be0bacd060de5db13ad1c8f20bfafa06aa3cf2b3ffc12336a7b8cb0eb8d0f4ae0040ea1b9c4727f54c
+    "@smithy/types": ^3.0.0
+    "@smithy/util-hex-encoding": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 4cd51bb8451a7df0c6de76284869bf966848f57b7f66be941c00bd141293f535632dd34d55f0bd8994254bfedffa535a4ea90e8b2debd2618e8dd3646b68f8ca
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-browser@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/eventstream-serde-browser@npm:1.0.1"
+"@smithy/eventstream-serde-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-browser@npm:3.0.0"
   dependencies:
-    "@smithy/eventstream-serde-universal": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 98557e609383bac0ec582f7a209e60780a431645c7339471f909acb7f3c157795cb652c477d3c15f8d4df0cdcfdeb44e0573858d26960f5eaf9f3740e62248a0
+    "@smithy/eventstream-serde-universal": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: b2d235085e19a0ada96ed27fd52a4d33ab34a8c029bfb839a9a406935ffed72a6e970ba020c1129493b54ebd336344234fa4bac90af25975963ec74a2034f5c2
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-config-resolver@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/eventstream-serde-config-resolver@npm:1.0.1"
+"@smithy/eventstream-serde-config-resolver@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 68a821a2d84c392b7c00610f65bcfad2da1f4cf89cc1fc204010ff3e01242afbdeb51a898b2685142ae96e07c7654086d44a326e262928c9da1c2ce537d2aa57
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: cc9e21af4a42a008897e4e34c40792021c105cc7a2c164719f27ed5cfadf3997bf529e12df9e3c980e62f756ecbdb5aa9a31c8d5b162d622825447b1984cf6e4
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-node@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/eventstream-serde-node@npm:1.0.1"
+"@smithy/eventstream-serde-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-node@npm:3.0.0"
   dependencies:
-    "@smithy/eventstream-serde-universal": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 300d434e2ba0de2a075fb9dbbccbd0dd2ecd95331b022ab26dfef2c6b88477e611c5b45e53e1a472ab0319a4b9598e287eafe3491e668d28ed1636c20782a4a6
+    "@smithy/eventstream-serde-universal": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: b9d0f24454ee1e459587cbc3e1fe9aa6fac31cf2175da022c2cb3a84587dfa838f980c6a58d63216bd1c8ad77f2b03733b16f3a597c8e068a6b1847d46ba77f6
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-universal@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/eventstream-serde-universal@npm:1.0.1"
+"@smithy/eventstream-serde-universal@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/eventstream-serde-universal@npm:3.0.0"
   dependencies:
-    "@smithy/eventstream-codec": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: bf2d3cdba972e3987c85737740c717f548ba803186e18dba8ba6fe30aa5b8b8636bc5c0fe0bc36a2a8377d1be4991dc568b47611257b61e1e1af6e0445089796
+    "@smithy/eventstream-codec": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: f833757a8c11d2d23365f15a0f47bd8d6d20f947bbbb80595dd88c63d5dbc62463d2189e23931e7730e73ad3f7b4eb960dd6f84648b52e5d0217854e4bf5afa7
   languageName: node
   linkType: hard
 
-"@smithy/fetch-http-handler@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/fetch-http-handler@npm:1.0.1"
+"@smithy/fetch-http-handler@npm:^3.0.0, @smithy/fetch-http-handler@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@smithy/fetch-http-handler@npm:3.0.1"
   dependencies:
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/querystring-builder": ^1.0.1
-    "@smithy/types": ^1.1.0
-    "@smithy/util-base64": ^1.0.1
-    tslib: ^2.5.0
-  checksum: ed13d1c9f4c663397f38c24e2c865946c5270e4361338fa57a4822fd57be1e8fd5618328ff200037e22534252d1f4f0646f03e2bfdc75d4cb935986509439673
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/querystring-builder": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-base64": ^3.0.0
+    tslib: ^2.6.2
+  checksum: ddb6e1ad989f5f02e7af7ea17a2f8e742f99e53358d64c57803a4fa9dd12e2a4a1c5c5ff69e912937bed661a6a4c583eb184c5e159be720170b686d66647dd01
   languageName: node
   linkType: hard
 
-"@smithy/hash-node@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/hash-node@npm:1.0.1"
+"@smithy/hash-blob-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/hash-blob-browser@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    "@smithy/util-buffer-from": ^1.0.1
-    "@smithy/util-utf8": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 94caff8828ced93e276a42b8488880ecd77bc945d7055ec1a17ceda749ffca2420d26b0611634b1db4629d0b80311f6d890a6ab3cca3dd1b986e81a261515f8c
+    "@smithy/chunked-blob-reader": ^3.0.0
+    "@smithy/chunked-blob-reader-native": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: d21f68cf3747df9c3fc8396a7327c081850a37bb672b7d2f26be895680d9fafda8b7d121da8feb10b4980470501d6db86842229c77a644d262a55828ddd99dcd
   languageName: node
   linkType: hard
 
-"@smithy/invalid-dependency@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/invalid-dependency@npm:1.0.1"
+"@smithy/hash-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/hash-node@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 9e6d20a53aa6e01032496d00e4c6ffbde5040b151e896b57b44dc9f8b58cf259a3f82804250312800957355c8044c3f8e96f187265c30c01077b06207395e24f
+    "@smithy/types": ^3.0.0
+    "@smithy/util-buffer-from": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: ef2520c1e5c7dc7669a2870881edaa9fac07e2bffa300d2434d599453dbce1b0c5239de6fb6d55f121a467e144a1f5c6d7f8d1ddf4547ce86d3e81827289752d
   languageName: node
   linkType: hard
 
-"@smithy/is-array-buffer@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/is-array-buffer@npm:1.0.1"
+"@smithy/hash-stream-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/hash-stream-node@npm:3.0.0"
   dependencies:
-    tslib: ^2.5.0
-  checksum: 1b582c19694e95c663c2ca499a1146189d4b54556813fff0029dd81c609c9fee80fb8a69e1e2197d45a67c962f64a2262808d944af878c0af3ae1da599ef3a06
+    "@smithy/types": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 7eaf7010127f1571ed5e3ffbc469500a8f41234fa17eaf818e721699ba1d049fa8244c580b59980a0eb9d777d4f7dbf0da594bf13f0b421dd6d73d9bfaa39b7c
   languageName: node
   linkType: hard
 
-"@smithy/md5-js@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/md5-js@npm:1.0.1"
+"@smithy/invalid-dependency@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/invalid-dependency@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    "@smithy/util-utf8": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 4c2cd45d7515cc1ca0cef01a3ffc80cd6d5c02064a6dfce3a81995059fc76f02b85e0836bf3195f2eae58eec86942eaecb26dc3c7a2489855fd489ff83886ebd
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 3227d5d8ba49d6ca09f95215614d41b75a717985ac2f5c4caa5c082dc87e1a510e1d1af738fe27cdb93c8425a189b2ec74a7d57d949cefa8cbcd62ed83ceb798
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/middleware-content-length@npm:1.0.1"
+"@smithy/is-array-buffer@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/is-array-buffer@npm:3.0.0"
   dependencies:
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 93847fcb2205e139fda49a6c4d50878f017f3c810338116a5bfcfe977154246a6fb485aac51f163d36d94f2f4caac84c8a86d08296aae0ac1d603df47893f71e
+    tslib: ^2.6.2
+  checksum: ce7440fcb1ce3c46722cff11c33e2f62a9df86d74fa2054a8e6b540302a91211cf6e4e3b1b7aac7030c6c8909158c1b6867c394201fa8afc6b631979956610e5
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "@smithy/middleware-endpoint@npm:1.0.2"
+"@smithy/md5-js@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/md5-js@npm:3.0.0"
   dependencies:
-    "@smithy/middleware-serde": ^1.0.1
-    "@smithy/types": ^1.1.0
-    "@smithy/url-parser": ^1.0.1
-    "@smithy/util-middleware": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 6a5182c1c676311f8e41d603725c7401a26dfcbbc7f0ccca20cd2213a666c6a764791444d6f24b681b770ea7484f0765cc019ba1ac946a442d966cb51ed28cc8
+    "@smithy/types": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: da315e784afe453545f1458d54c0845ba87f55fc5069e9a90c3fdee58123a45ef515390d4637a3e4270c0a06cda1a923ba236e36a5f5c6b5afcaebfdc49cde22
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^1.0.1, @smithy/middleware-retry@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "@smithy/middleware-retry@npm:1.0.3"
+"@smithy/middleware-content-length@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-content-length@npm:3.0.0"
   dependencies:
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/service-error-classification": ^1.0.2
-    "@smithy/types": ^1.1.0
-    "@smithy/util-middleware": ^1.0.1
-    "@smithy/util-retry": ^1.0.3
-    tslib: ^2.5.0
-    uuid: ^8.3.2
-  checksum: b9d829be9f2ce623604a23e4104126b4a7c2cfa17278ba4a1890cf6f0bab9430183b81979564d360b4ac3f5a7731366fec064f4bed718786345304ac4608de7f
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 658474b9c10696f701ae32a741c357192d4e8e1f409855093a3660fa21d4785972f2ec1c6973d159a875437a414c4f6e64b2fd0e12a7242cb5d73679b3283667
   languageName: node
   linkType: hard
 
-"@smithy/middleware-serde@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/middleware-serde@npm:1.0.1"
+"@smithy/middleware-endpoint@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-endpoint@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 06c783fcf97366a350c4f0df033d203d559d0ee55b72c06a5fa8e826a3c58bd661525b7dcc16b4bfdc859ea106d28070ae131629b2da64e001b507b3a8043319
+    "@smithy/middleware-serde": ^3.0.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/shared-ini-file-loader": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/url-parser": ^3.0.0
+    "@smithy/util-middleware": ^3.0.0
+    tslib: ^2.6.2
+  checksum: a1be07b91f4ddcd6b5358bb8b43529756a80aefb451bd95b2d69e5743229ad7c8d55eed0ad73225301b833dd05173760fa0453891640d4407b4d8f4006c566f5
   languageName: node
   linkType: hard
 
-"@smithy/middleware-stack@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/middleware-stack@npm:1.0.1"
+"@smithy/middleware-retry@npm:^3.0.0, @smithy/middleware-retry@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@smithy/middleware-retry@npm:3.0.1"
   dependencies:
-    tslib: ^2.5.0
-  checksum: fe428320fee64972dc5f5bfafd199f78267c028c47baeb972ea501f0e56e69e6c8692152ddcd57908a2db719866bdd0698aa672a9bf5a28ffc075823b8800c0e
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/service-error-classification": ^3.0.0
+    "@smithy/smithy-client": ^3.0.1
+    "@smithy/types": ^3.0.0
+    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-retry": ^3.0.0
+    tslib: ^2.6.2
+    uuid: ^9.0.1
+  checksum: 33b1c5173ccbcbfd8127ef6009ec167d80fbd539cad35372b25a05b75b1a3b999bba39a3327a46916f41512d8ee4d3d6cfd56bbfdc36867118bee9cac4d94ab3
   languageName: node
   linkType: hard
 
-"@smithy/node-config-provider@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/node-config-provider@npm:1.0.1"
+"@smithy/middleware-serde@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-serde@npm:3.0.0"
   dependencies:
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/shared-ini-file-loader": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: ac85f8f368ff2cfa27c58492eb15a25cde5503cabbf0df663b78474045e11abf7988d947c221dfea0e7272c8e44c92a273004b822f67990841b4e9792ef38699
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 9520948ab8fbe50f17eb4fdc2065a068cc9b954c876c354c355cd729ad29790815c4acd4fdafe32456e81308ec2266d35e82aa69fedbcb0cad1981785fc87c25
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^1.0.1, @smithy/node-http-handler@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@smithy/node-http-handler@npm:1.0.2"
+"@smithy/middleware-stack@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/middleware-stack@npm:3.0.0"
   dependencies:
-    "@smithy/abort-controller": ^1.0.1
-    "@smithy/protocol-http": ^1.1.0
-    "@smithy/querystring-builder": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: ed0c84000a8409c899e6ac9060833b85463dd7e93ec77bdef5406e26f7026964769a12ec83c54bc037e7b828b33ed8b96fae57d16f520fb04dbc363e7a8ad74f
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: ca2e9e41aa78dc0e50b51cf94ff3d85ee86a0e241dde5f41640bf4401b862519ba52824c2ad04d861f6e9325749bacfd5ff4be0fef67c8b6f084c9935cce57ca
   languageName: node
   linkType: hard
 
-"@smithy/property-provider@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/property-provider@npm:1.0.1"
+"@smithy/node-config-provider@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/node-config-provider@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 5700a745fee2afcc878fd4eab4dc4497a01d1cbfdc9db18bf07c22cb9d27a7baa4622d94ee09915ae780fced6f301e8af187a4d84408200b6b476cb8a362b362
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/shared-ini-file-loader": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 2c2de21e40bcaf85faa27fe856d0c61257fd05c6b205eb7799a26cf1bea7c25023f7951b0b48730c8b77569a3a762ddaa462c5eca193ae051431ebd553c1e637
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^1.0.1, @smithy/protocol-http@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@smithy/protocol-http@npm:1.1.0"
+"@smithy/node-http-handler@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/node-http-handler@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: f912e085a477664abf38ff4cd0c2ac064ef068afc6cc0a09ce9c2849f07bac8be622edf60f19a91e2701184b63daa85cb2898e243d7a2c6fd1613de705b3152c
+    "@smithy/abort-controller": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/querystring-builder": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 194542f2abbc1f1ccd9655eb4d06b2fead212e71954d20ca429904dfd7c49f2ea13c06604c31cd7700af53971d86534ec9e0b53c16479dc1491569a99aee67d7
   languageName: node
   linkType: hard
 
-"@smithy/querystring-builder@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/querystring-builder@npm:1.0.1"
+"@smithy/property-provider@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/property-provider@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    "@smithy/util-uri-escape": ^1.0.1
-    tslib: ^2.5.0
-  checksum: f8f0a9e008ae57de97679dc56220605814ada930c362afa39259c507e778ce123fb0cd4581c8dcda0a4d8862e524c1af7b712770b983e35863312d8f283388f8
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 741cb59b7eab30910a2e38bee1c489120d6b6ef4b3682d556abcf9ddf545a9249902281d72f4a0282953e6f2ec9b6aa0bac8e5003cb0ff389475b4c793ac83e1
   languageName: node
   linkType: hard
 
-"@smithy/querystring-parser@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/querystring-parser@npm:1.0.1"
+"@smithy/protocol-http@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@smithy/protocol-http@npm:4.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: a62ea8df9bd266a00cd93d7ea1a629c96fe60d083e0ad1b761b63c77253d66f89b66049d36ea33faa5fdc7acf766c342997d667094c2fb3a5f6910da90ef8db4
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 0cea8e4933b1ca888f755495ac10cec9191678eb3425b755443479a1653223eede0d031a3b4cc04a34b80c4ed7b06d7e0a576f577988d876b81982aa84e31bfc
   languageName: node
   linkType: hard
 
-"@smithy/service-error-classification@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@smithy/service-error-classification@npm:1.0.2"
-  checksum: e6a5298d77f02fca257c37ca0547c4039dd58b6d522a1826aa958639a270c3d78de6694589835d216813915f5b7a146bf5f7a818174ab668a3aa0aa77489a02a
-  languageName: node
-  linkType: hard
-
-"@smithy/shared-ini-file-loader@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/shared-ini-file-loader@npm:1.0.1"
+"@smithy/querystring-builder@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/querystring-builder@npm:3.0.0"
   dependencies:
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 07b6e85979ad9ef9ab73946f5a35efb1432135baaa93abcc241b6773cd385c5def4775b18c63e7aac3548205e81f7430718a6db785f0ff461e3414488d46c7d0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-uri-escape": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 28a8a243002560f0928bf73b4686a0f81ed867957a033c2fc9fb249fb7006f076e78fcb506c96956e9d1d5e34a4c6228d0aeb7fcdc9418cdfe3377084e0654f4
   languageName: node
   linkType: hard
 
-"@smithy/signature-v4@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/signature-v4@npm:1.0.1"
+"@smithy/querystring-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/querystring-parser@npm:3.0.0"
   dependencies:
-    "@smithy/eventstream-codec": ^1.0.1
-    "@smithy/is-array-buffer": ^1.0.1
-    "@smithy/types": ^1.1.0
-    "@smithy/util-hex-encoding": ^1.0.1
-    "@smithy/util-middleware": ^1.0.1
-    "@smithy/util-uri-escape": ^1.0.1
-    "@smithy/util-utf8": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 4696f81c795e42e40a2ecc9e46b80f2d52898034f3a1ea6b1c5543741dc968772ae32ab9c49608c1952c997b33340a43a56cd138187a17b146e3b31e8ba886ba
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 5b76846e1ef0e19d4cd249089184597476b2f82ff491952b7f61d0dc8705b8596f9d8579fe3c2ce6b61dff61271990c35c85c89aba3724e781b4993afc816a2a
   languageName: node
   linkType: hard
 
-"@smithy/smithy-client@npm:^1.0.2, @smithy/smithy-client@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@smithy/smithy-client@npm:1.0.3"
+"@smithy/service-error-classification@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/service-error-classification@npm:3.0.0"
   dependencies:
-    "@smithy/middleware-stack": ^1.0.1
-    "@smithy/types": ^1.1.0
-    "@smithy/util-stream": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 5b6092cfcece07c4732cf8b4f54f381bcbc3850a8a0409d287ae84e3cc13e9b527ad4a2c3a481c80ff52204b4e90bde7c26a722cf7e77f74ac8e651d40f50801
+    "@smithy/types": ^3.0.0
+  checksum: 44ad8cd553896c8608d411763d962f5a758bc86fc49f58ef70b2d2a26f5a9189d1bfa0eed13cfe457cf7bfbedcb2c3e4b6e77bd93bb534f6bef6da74ab776807
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:1.1.0, @smithy/types@npm:^1.0.0, @smithy/types@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@smithy/types@npm:1.1.0"
+"@smithy/shared-ini-file-loader@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/shared-ini-file-loader@npm:3.0.0"
   dependencies:
-    tslib: ^2.5.0
-  checksum: 8c0589fa973e5c71cf776c28c43aba04ee07139578fd0174aac0d74c3688e3ffa7075cecd65b223b2a155ad711808b1e4ad58a084ba9f24fcb49679272018387
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: d8f0d6e8f30293adc7ad0f3877d37c827e04abbcee70750b6f25be0f6fc2b80b659beadb35562f6d2312d5b437cb801241c3c5610986228b83ca3a5c2c1071dd
   languageName: node
   linkType: hard
 
-"@smithy/url-parser@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/url-parser@npm:1.0.1"
+"@smithy/signature-v4@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/signature-v4@npm:3.0.0"
   dependencies:
-    "@smithy/querystring-parser": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: ced0dba0131b352459e19bad259231b920b16f9c0131643676741a9d8e1aec48181db34d0518bd9933b0f80107b95359890b52705156530d9f9fa9a8580c879d
+    "@smithy/is-array-buffer": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-hex-encoding": ^3.0.0
+    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-uri-escape": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 18962f427e33843014e7886bb5b8c3164150a87c5c604f48e6a080017d12f04fd55b1a7776f0f438cc641a2472b75d98c7173a34b9335dcd6a89c55fc1c65dd4
   languageName: node
   linkType: hard
 
-"@smithy/util-base64@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-base64@npm:1.0.1"
+"@smithy/smithy-client@npm:^3.0.0, @smithy/smithy-client@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@smithy/smithy-client@npm:3.0.1"
   dependencies:
-    "@smithy/util-buffer-from": ^1.0.1
-    tslib: ^2.5.0
-  checksum: 8ac7a8562cd13aff0e6b49aafae5ec18fda7f61a1e172cfed97eddd0b5b5b5805608a2a78de964d0234e6274922bdd6ab7eb32e429ab8b605b840af2fc2e3614
+    "@smithy/middleware-endpoint": ^3.0.0
+    "@smithy/middleware-stack": ^3.0.0
+    "@smithy/protocol-http": ^4.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-stream": ^3.0.1
+    tslib: ^2.6.2
+  checksum: 901107c8bc7b80e0e1798210f996a30a9af441a48d399bbc89ed94790a3d2d93263896f71d2139c9ab4d2f40e5e752d233abad45621e33ba2eed8e390f38c364
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-browser@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-body-length-browser@npm:1.0.1"
+"@smithy/types@npm:3.0.0, @smithy/types@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/types@npm:3.0.0"
   dependencies:
-    tslib: ^2.5.0
-  checksum: b4afec282504b972a4f488324f319d22305013a4ef965a8812e7a78b7031a27c804638af87540a69eb27e91a55c52ca54d39583fb885e15a81901887e05e20aa
+    tslib: ^2.6.2
+  checksum: 1c9c196c781aec0bed7c1519f91030ca4301f30f969394b099ccaa6ab0b47e55b211f54ae56a5a101e91d64899f147d49861e77c24fdc56117cf191a300e00ec
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-node@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-body-length-node@npm:1.0.1"
+"@smithy/url-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/url-parser@npm:3.0.0"
   dependencies:
-    tslib: ^2.5.0
-  checksum: a70440e32caa776a854eaff528e514cad38cad27fa548e45f150f3a3e1bb506a08e0468ea30149e60ed735c157cfd56055e809ac5422ab94964930afe77415f4
+    "@smithy/querystring-parser": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: dd92f24432b90cdd4aa80b3b3cd7f5075a54248756f87e4961cb1d7c52483cee44b3f98c96fefd01e8cc5bd2744e7d658ec547cdb6cdc7365f46c0f7df2b3eb2
   languageName: node
   linkType: hard
 
-"@smithy/util-buffer-from@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-buffer-from@npm:1.0.1"
+"@smithy/util-base64@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-base64@npm:3.0.0"
   dependencies:
-    "@smithy/is-array-buffer": ^1.0.1
-    tslib: ^2.5.0
-  checksum: bfb18108d8fc0e55dd4b2e2dbe88a017f43e186e96d9b4f541b49363ac95d8f7461d7df0388a556528bea4eb91639377d748addf5c9b42fffab66d67983f022f
+    "@smithy/util-buffer-from": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 413f26046a7e98b2661a078f218a8d040c820fc5a02f5e364aff58c3957e28fde1ac4048c2ebbad5d87b9da4b9aa98a8d4a7fb0d2ce97def33738bd7d8d79aa0
   languageName: node
   linkType: hard
 
-"@smithy/util-config-provider@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-config-provider@npm:1.0.1"
+"@smithy/util-body-length-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-body-length-browser@npm:3.0.0"
   dependencies:
-    tslib: ^2.5.0
-  checksum: 5365b79d39e6aaa9eec7ea958929b285a068947330cee659afa919b21ab5f2e43da4209c6e3f48a35d854f64b893447be7cf80994b6e869d99c92f8dcb1ea53e
+    tslib: ^2.6.2
+  checksum: b01d8258b9a25b262734fc49cefefe48583ba193c3eefd49a6f7fd5922c3015d23dda88b52f3dd9a16827cad16b5b9425eef01e91bd0c71bb5abc469d2952c07
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-defaults-mode-browser@npm:1.0.1"
+"@smithy/util-body-length-node@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-body-length-node@npm:3.0.0"
   dependencies:
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/types": ^1.1.0
+    tslib: ^2.6.2
+  checksum: da1baf4790609d3dc28c88385c7274fdf9b91a641fe3c5af22b78e18156df17bd470181348f43b2c739680936b1dafb1526158dfd817c3d9ecb71e653b4cbe3f
+  languageName: node
+  linkType: hard
+
+"@smithy/util-buffer-from@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-buffer-from@npm:3.0.0"
+  dependencies:
+    "@smithy/is-array-buffer": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 1bfc4ab093fe98132bbc1ccd36a0b9ad75a31ed26bac4b7e9350205513a2481eb190ae44679ab4fecc5e10d367b5e6592bbfbf792671579d17d17bd7f7f233f5
+  languageName: node
+  linkType: hard
+
+"@smithy/util-config-provider@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-config-provider@npm:3.0.0"
+  dependencies:
+    tslib: ^2.6.2
+  checksum: fc0f5f57d30261cf3a6693d8e338b9d269332c478ee18d905309a769844188190caf0564855d7e84f6c61e56aa556195dda89f65e8c30791951cf4999e4a70e7
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-browser@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "@smithy/util-defaults-mode-browser@npm:3.0.1"
+  dependencies:
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/smithy-client": ^3.0.1
+    "@smithy/types": ^3.0.0
     bowser: ^2.11.0
-    tslib: ^2.5.0
-  checksum: 510cab3dfd892e73e47776cb47c4dc63bd4728c6f12c93f2907a806ab84ab960ba4073132e593ed9a93f8f47a9c4a075c2424d7309591a38219dc8ca732fb762
+    tslib: ^2.6.2
+  checksum: eaf4389187d4c2e7f77010fceb4b10c3e396654d634ff1ef5c66164e86049000fe30eca010f637824ab88b7a9e501fcd08cab7a8b523468af6735b397e481e9a
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-defaults-mode-node@npm:1.0.1"
+"@smithy/util-defaults-mode-node@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "@smithy/util-defaults-mode-node@npm:3.0.1"
   dependencies:
-    "@smithy/config-resolver": ^1.0.1
-    "@smithy/credential-provider-imds": ^1.0.1
-    "@smithy/node-config-provider": ^1.0.1
-    "@smithy/property-provider": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: dde9cc0cde9bfa9561256da63d8ce60d0c08144f13d43e39a947d59bf06e94b7eb9994d5e45e406c442eea8b1dd36f980045a644d0995b64012fadadaef3dc99
+    "@smithy/config-resolver": ^3.0.0
+    "@smithy/credential-provider-imds": ^3.0.0
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/property-provider": ^3.0.0
+    "@smithy/smithy-client": ^3.0.1
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 2355a03b69f56d34e19653597fda1df5e598a04a5c9139a1902dd658b4d883a7c24b04f0e038043daa874f02f7ead719ce2ef2c1d0f9d83bc02a8ea120357469
   languageName: node
   linkType: hard
 
-"@smithy/util-hex-encoding@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-hex-encoding@npm:1.0.1"
+"@smithy/util-endpoints@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-endpoints@npm:2.0.0"
   dependencies:
-    tslib: ^2.5.0
-  checksum: 8a5da7863a9541d56f9aa07d0acee03589ebabe35b8b037a186bd3639c827f2b18083b8b2f836a0f691001630a675d8b652d9b395c5d4c394858eff4c145fc60
+    "@smithy/node-config-provider": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 0c4d33ace7bf3d76b6e563f2a07e43a49d6a367d7874dcfc7f06c97accc5307f5e881aea7ea782f3a05e5ddf9e1e2e238070d563496423c048d115f539fc9941
   languageName: node
   linkType: hard
 
-"@smithy/util-middleware@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-middleware@npm:1.0.1"
+"@smithy/util-hex-encoding@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-hex-encoding@npm:3.0.0"
   dependencies:
-    tslib: ^2.5.0
-  checksum: e6c143b1727954c3871707b3b8f0ce5b9c7ca5ec3343144c89d132158f7cd8dba93afd29be0007e8d12824add245627c2651eb12419439a4c209509e859c5b1f
+    tslib: ^2.6.2
+  checksum: dd32fd71e915825987a18bf7c0f8f0c4956d0b17a0ee71592b5563bb20e04f24dbf81d36161aac07caab3bb5e535cc609fce20aa4a38f66b457c4c6f5c7748d9
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^1.0.1, @smithy/util-retry@npm:^1.0.2, @smithy/util-retry@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@smithy/util-retry@npm:1.0.3"
+"@smithy/util-middleware@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-middleware@npm:3.0.0"
   dependencies:
-    "@smithy/service-error-classification": ^1.0.2
-    tslib: ^2.5.0
-  checksum: ebded11887a3adbe61396ce6fbbcaa72797c02f939f5471648ee0cb27d007186e6b5ed6a575b553e7b51d579af2cba37cfe7ce0e32548588296b4ae9f427f112
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: ab73eb58942733f832a730b4ed29013eb2c1ea04b6d108b82aee92b832ba2c1e73f78dcbf7aaeab9403583b92f85b7dbc7b33d22d1d37f0900a814bfdea19cc9
   languageName: node
   linkType: hard
 
-"@smithy/util-stream@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-stream@npm:1.0.1"
+"@smithy/util-retry@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-retry@npm:3.0.0"
   dependencies:
-    "@smithy/fetch-http-handler": ^1.0.1
-    "@smithy/node-http-handler": ^1.0.2
-    "@smithy/types": ^1.1.0
-    "@smithy/util-base64": ^1.0.1
-    "@smithy/util-buffer-from": ^1.0.1
-    "@smithy/util-hex-encoding": ^1.0.1
-    "@smithy/util-utf8": ^1.0.1
-    tslib: ^2.5.0
-  checksum: faf57c8b2f6b8df69a989df99f47129099d6ee79e47295ea41bb0465cfd028acc4adb9d88570ea0ec9b555dd261df7bdde2258476d88da34ae92d8c00651e1f3
+    "@smithy/service-error-classification": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 699fb2da6d97e903b9aec3883fd9f8e3477a03d377705840ca9bf12b440d803db89742bc8cf239448287b0369672dd6076afd3e663322106302217623a76d855
   languageName: node
   linkType: hard
 
-"@smithy/util-uri-escape@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-uri-escape@npm:1.0.1"
+"@smithy/util-stream@npm:^3.0.0, @smithy/util-stream@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@smithy/util-stream@npm:3.0.1"
   dependencies:
-    tslib: ^2.5.0
-  checksum: 109a4ab88c85a9aac829a273f1fc1f6fa442f6651f348d6341eccbabd09f4c71fd825e0cdfcc3ec8027152a3a0ca498c2775df6999075eff5a3cf6e4cd08c165
+    "@smithy/fetch-http-handler": ^3.0.1
+    "@smithy/node-http-handler": ^3.0.0
+    "@smithy/types": ^3.0.0
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-buffer-from": ^3.0.0
+    "@smithy/util-hex-encoding": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 1b691d77470722d2a29e5294f2802161ef54d45ded78d27c0d53f9bb84051407673579cf70f9c6e810e419d2ba8446acd17e1dde60f219a6df3b8d66476b0071
   languageName: node
   linkType: hard
 
-"@smithy/util-utf8@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-utf8@npm:1.0.1"
+"@smithy/util-uri-escape@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-uri-escape@npm:3.0.0"
   dependencies:
-    "@smithy/util-buffer-from": ^1.0.1
-    tslib: ^2.5.0
-  checksum: ddb841cfe8314a9fd7036a6240bcaeab2470dbaf318f9dfcbf4b3721a8b070b98c72c0ede3f5a7f98c0f5f7db82c26ace47ee4a1a7723024bde1764324c2a59f
+    tslib: ^2.6.2
+  checksum: d7ee01c978e2b08d0a89a3b678f5d5e5d5bb4ab4ab85567a238b1a6195dff1bdaf9ae62497e7f32ff5121b3dc007c370bcb6e8ef79b01fe5acdec5bbce8c7ce4
   languageName: node
   linkType: hard
 
-"@smithy/util-waiter@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@smithy/util-waiter@npm:1.0.1"
+"@smithy/util-utf8@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-utf8@npm:3.0.0"
   dependencies:
-    "@smithy/abort-controller": ^1.0.1
-    "@smithy/types": ^1.1.0
-    tslib: ^2.5.0
-  checksum: 24342710f6883ed21dde75a7f6a9b2141611fbb6820554a75f370ee5ad172576d6783e1ef946916ecf6911161a764569f8a42f066897a03e5291ed050f5b87bf
+    "@smithy/util-buffer-from": ^3.0.0
+    tslib: ^2.6.2
+  checksum: d97be1748963263a1161ba80417d82318b977b38542f3fdf0379b0162461188be680e5bfb66a89d65652f0fad6ecf2ab23a43205979216e50602488f73434da3
+  languageName: node
+  linkType: hard
+
+"@smithy/util-waiter@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/util-waiter@npm:3.0.0"
+  dependencies:
+    "@smithy/abort-controller": ^3.0.0
+    "@smithy/types": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 9e6aba7175abf6f96b2a15ece6ca1eb3a218bb494df0bb3a14c3e9bc59caf078ba5fe48e3a073d3f20ee65cb483f3b12e56808bfe1f094e28a21a3eceadfd045
   languageName: node
   linkType: hard
 
@@ -3513,9 +3616,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aws-sdk-client-mock-jest@workspace:packages/aws-sdk-client-mock-jest"
   dependencies:
-    "@aws-sdk/client-sns": 3.363.0
+    "@aws-sdk/client-sns": 3.577.0
     "@jest/globals": 29.7.0
-    "@smithy/types": 1.1.0
+    "@smithy/types": 3.0.0
     "@types/jest": 29.5.11
     aws-sdk-client-mock: "workspace:*"
     expect: 29.7.0
@@ -3554,16 +3657,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aws-sdk-client-mock@workspace:packages/aws-sdk-client-mock"
   dependencies:
-    "@aws-sdk/client-dynamodb": 3.363.0
-    "@aws-sdk/client-s3": 3.363.0
-    "@aws-sdk/client-sns": 3.363.0
-    "@aws-sdk/client-sqs": 3.363.0
-    "@aws-sdk/lib-dynamodb": 3.363.0
-    "@smithy/types": 1.1.0
+    "@aws-sdk/client-dynamodb": 3.577.0
+    "@aws-sdk/client-s3": 3.577.0
+    "@aws-sdk/client-sns": 3.577.0
+    "@aws-sdk/client-sqs": 3.577.0
+    "@aws-sdk/lib-dynamodb": 3.577.0
+    "@smithy/types": 3.0.0
     "@types/sinon": ^10.0.10
     sinon: ^16.1.3
     tslib: ^2.1.0
-    typedoc: 0.23.26
+    typedoc: 0.25.13
   languageName: unknown
   linkType: soft
 
@@ -7677,12 +7780,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^4.2.12":
-  version: 4.2.12
-  resolution: "marked@npm:4.2.12"
+"marked@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "marked@npm:4.3.0"
   bin:
     marked: bin/marked.js
-  checksum: bd551cd61028ee639d4ca2ccdfcc5a6ba4227c1b143c4538f3cde27f569dcb57df8e6313560394645b418b84a7336c07ab1e438b89b6324c29d7d8cdd3102d63
+  checksum: 0db6817893952c3ec710eb9ceafb8468bf5ae38cb0f92b7b083baa13d70b19774674be04db5b817681fa7c5c6a088f61300815e4dd75a59696f4716ad69f6260
   languageName: node
   linkType: hard
 
@@ -7868,12 +7971,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^7.1.3, minimatch@npm:^7.4.1":
+"minimatch@npm:^7.4.1":
   version: 7.4.2
   resolution: "minimatch@npm:7.4.2"
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 9e341b04e69d5ab03e4206dcb61c8a158e3b8709628bf5e1a4eaa9f3b72c0ba925e24ad959b1f6ce6835caa5a927131d5087fae6836b69e7d99d7d5e63ef0bd8
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.3":
+  version: 9.0.4
+  resolution: "minimatch@npm:9.0.4"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: cf717f597ec3eed7dabc33153482a2e8d49f4fd3c26e58fd9c71a94c5029a0838728841b93f46bf1263b65a8010e2ee800d0dc9b004ab8ba8b6d1ec07cc115b5
   languageName: node
   linkType: hard
 
@@ -9323,15 +9435,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shiki@npm:^0.14.1":
-  version: 0.14.1
-  resolution: "shiki@npm:0.14.1"
+"shiki@npm:^0.14.7":
+  version: 0.14.7
+  resolution: "shiki@npm:0.14.7"
   dependencies:
     ansi-sequence-parser: ^1.1.0
     jsonc-parser: ^3.2.0
     vscode-oniguruma: ^1.7.0
     vscode-textmate: ^8.0.0
-  checksum: b19ea337cc84da69d99ca39d109f82946e0c56c11cc4c67b3b91cc14a9479203365fd0c9e0dd87e908f493ab409dc6f1849175384b6ca593ce7da884ae1edca2
+  checksum: 2aec3b3519df977c4391df9e1825cb496e9a4d7e11395f05a0da77e4fa2f7c3d9d6e6ee94029ac699533017f2b25637ee68f6d39f05f311535c2704d0329b520
   languageName: node
   linkType: hard
 
@@ -10060,6 +10172,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
+  languageName: node
+  linkType: hard
+
 "tsscmp@npm:1.0.6":
   version: 1.0.6
   resolution: "tsscmp@npm:1.0.6"
@@ -10192,19 +10311,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:0.23.26":
-  version: 0.23.26
-  resolution: "typedoc@npm:0.23.26"
+"typedoc@npm:0.25.13":
+  version: 0.25.13
+  resolution: "typedoc@npm:0.25.13"
   dependencies:
     lunr: ^2.3.9
-    marked: ^4.2.12
-    minimatch: ^7.1.3
-    shiki: ^0.14.1
+    marked: ^4.3.0
+    minimatch: ^9.0.3
+    shiki: ^0.14.7
   peerDependencies:
-    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x
   bin:
     typedoc: bin/typedoc
-  checksum: 09dbd221b5bd27a7f6c593a6aa7e4efc3c46f20761e109a76bf0ed7239011cca1261357094710c01472582060d75a7558aab5bf5b78db3aff7c52188d146ee65
+  checksum: 703d1f48137300b0ef3df1998a25ae745db3ca0b126f8dd1f7262918f11243a94d24dfc916cdba2baeb5a7d85d5a94faac811caf7f4fa6b7d07144dc02f7639f
   languageName: node
   linkType: hard
 
@@ -10322,12 +10441,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
   bin:
     uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Last version of AWS SDK is using Smithy types 3.0.0, no more 1.1.0.
So let's try this bump
Is it related to this issue : https://github.com/m-radzikowski/aws-sdk-client-mock/issues/197 ?