### PR TITLE
chore: bump sinon from 16.1.3 to 18.0.1

### DIFF
--- a/packages/aws-sdk-client-mock-jest/package.json
+++ b/packages/aws-sdk-client-mock-jest/package.json
@@ -48,7 +48,7 @@
     "@jest/globals": "29.7.0",
     "@smithy/types": "1.1.0",
     "@types/jest": "29.5.12",
-    "@types/sinon": "^10.0.10",
+    "@types/sinon": "^17.0.3",
     "aws-sdk-client-mock": "workspace:*",
     "expect": "29.7.0",
     "jest-serializer-ansi-escapes": "3.0.0"

--- a/packages/aws-sdk-client-mock/package.json
+++ b/packages/aws-sdk-client-mock/package.json
@@ -39,8 +39,8 @@
     "dist"
   ],
   "dependencies": {
-    "@types/sinon": "^10.0.10",
-    "sinon": "^16.1.3",
+    "@types/sinon": "^17.0.3",
+    "sinon": "^18.0.1",
     "tslib": "^2.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,11 +66,11 @@ importers:
   packages/aws-sdk-client-mock:
     dependencies:
       '@types/sinon':
-        specifier: ^10.0.10
-        version: 10.0.20
+        specifier: ^17.0.3
+        version: 17.0.3
       sinon:
-        specifier: ^16.1.3
-        version: 16.1.3
+        specifier: ^18.0.1
+        version: 18.0.1
       tslib:
         specifier: ^2.1.0
         version: 2.6.2
@@ -122,8 +122,8 @@ importers:
         specifier: 29.5.12
         version: 29.5.12
       '@types/sinon':
-        specifier: ^10.0.10
-        version: 10.0.20
+        specifier: ^17.0.3
+        version: 17.0.3
       aws-sdk-client-mock:
         specifier: workspace:*
         version: link:../aws-sdk-client-mock
@@ -1014,8 +1014,8 @@ packages:
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
-  '@types/sinon@10.0.20':
-    resolution: {integrity: sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==}
+  '@types/sinon@17.0.3':
+    resolution: {integrity: sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==}
 
   '@types/sinonjs__fake-timers@8.1.5':
     resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
@@ -2872,8 +2872,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  nise@5.1.9:
-    resolution: {integrity: sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==}
+  nise@6.0.0:
+    resolution: {integrity: sha512-K8ePqo9BFvN31HXwEtTNGzgrPpmvgciDsFz8aztFjt4LqKO/JeFD8tBOeuDiCMXrIl/m1YvfH8auSpxfaD09wg==}
 
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
@@ -3353,8 +3353,8 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  sinon@16.1.3:
-    resolution: {integrity: sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==}
+  sinon@18.0.1:
+    resolution: {integrity: sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -5458,7 +5458,7 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
-  '@types/sinon@10.0.20':
+  '@types/sinon@17.0.3':
     dependencies:
       '@types/sinonjs__fake-timers': 8.1.5
 
@@ -7665,7 +7665,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nise@5.1.9:
+  nise@6.0.0:
     dependencies:
       '@sinonjs/commons': 3.0.1
       '@sinonjs/fake-timers': 11.2.2
@@ -8137,13 +8137,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sinon@16.1.3:
+  sinon@18.0.1:
     dependencies:
       '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 10.3.0
+      '@sinonjs/fake-timers': 11.2.2
       '@sinonjs/samsam': 8.0.0
       diff: 5.2.0
-      nise: 5.1.9
+      nise: 6.0.0
       supports-color: 7.2.0
 
   sisteransi@1.0.5: {}


### PR DESCRIPTION
Bump sinon from 16.1.3 to 18.0.1

Changelog: https://github.com/sinonjs/sinon/blob/main/CHANGES.md