### PR TITLE
fix: use namespace imports instead of default imports and remove the need to enable `esModuleInterop` in tsconfig

### DIFF
--- a/packages/aws-sdk-client-mock-jest/src/jestMatchers.ts
+++ b/packages/aws-sdk-client-mock-jest/src/jestMatchers.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-interface */
-import assert from 'assert';
+import * as assert from 'assert';
 import type {MetadataBearer} from '@smithy/types';
 import {AwsCommand, AwsStub} from 'aws-sdk-client-mock';
 import type {SinonSpyCall} from 'sinon';

--- a/packages/aws-sdk-client-mock-jest/src/jestMatchers.ts
+++ b/packages/aws-sdk-client-mock-jest/src/jestMatchers.ts
@@ -275,8 +275,8 @@ const processMatch = <CheckData = undefined>({ctx, mockClient, command, check, m
     };
     message: (params: MessageFunctionParams<CheckData>) => string[];
 }): ExpectationResult => {
-    assert(mockClient instanceof AwsStub, 'The actual must be a client mock instance');
-    command && assert(
+    assert.ok(mockClient instanceof AwsStub, 'The actual must be a client mock instance');
+    command && assert.ok(
         command &&
         typeof command === 'function' &&
         typeof command.name === 'string' &&
@@ -310,7 +310,7 @@ const processMatch = <CheckData = undefined>({ctx, mockClient, command, check, m
 };
 
 const ensureNoOtherArgs = (args: unknown[]): void => {
-    assert(args.length === 0, 'Too many matcher arguments');
+    assert.ok(args.length === 0, 'Too many matcher arguments');
 };
 
 const baseMatchers: { [P in keyof AwsSdkJestMockBaseMatchers<unknown>]: MatcherFunction<any[]> } = {
@@ -398,7 +398,7 @@ const baseMatchers: { [P in keyof AwsSdkJestMockBaseMatchers<unknown>]: MatcherF
         ...other: unknown[]
     ) {
         ensureNoOtherArgs(other);
-        assert(
+        assert.ok(
             call && typeof call === 'number' && call > 0,
             'Call number must be a number greater than 0',
         );
@@ -453,7 +453,7 @@ const baseMatchers: { [P in keyof AwsSdkJestMockBaseMatchers<unknown>]: MatcherF
         ...other: unknown[]
     ) {
         ensureNoOtherArgs(other);
-        assert(
+        assert.ok(
             call && typeof call === 'number' && call > 0,
             'Call number must be a number greater than 0',
         );

--- a/packages/aws-sdk-client-mock/src/mockClient.ts
+++ b/packages/aws-sdk-client-mock/src/mockClient.ts
@@ -1,5 +1,5 @@
 import {Client, Command, MetadataBearer} from '@smithy/types';
-import sinon, {SinonSandbox, SinonStub} from 'sinon';
+import * as sinon from 'sinon';
 import {isSinonStub} from './sinon';
 import {AwsClientStub, AwsStub} from './awsClientStub';
 
@@ -12,7 +12,7 @@ import {AwsClientStub, AwsStub} from './awsClientStub';
  */
 export const mockClient = <TInput extends object, TOutput extends MetadataBearer, TConfiguration>(
     client: InstanceOrClassType<Client<TInput, TOutput, TConfiguration>>,
-    {sandbox}: { sandbox?: SinonSandbox } = {},
+    {sandbox}: { sandbox?: sinon.SinonSandbox } = {},
 ): AwsClientStub<Client<TInput, TOutput, TConfiguration>> => {
     const instance = isClientInstance(client) ? client : client.prototype;
 
@@ -22,7 +22,7 @@ export const mockClient = <TInput extends object, TOutput extends MetadataBearer
     }
 
     const sinonSandbox = sandbox || sinon;
-    const sendStub = sinonSandbox.stub(instance, 'send') as SinonStub<[Command<TInput, any, TOutput, any, any>], Promise<TOutput>>;
+    const sendStub = sinonSandbox.stub(instance, 'send') as sinon.SinonStub<[Command<TInput, any, TOutput, any, any>], Promise<TOutput>>;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return new AwsStub<TInput, TOutput, TConfiguration>(instance, sendStub);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "strict": true,
     "sourceMap": true,
     "declaration": true,
-    "esModuleInterop": true,
     "importHelpers": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
## Changes

Make the project suitable for usage in projects that have `esModuleInterop` disabled (or not set) in tsconfig.

* use namespace imports instead of default imports
* remove `esModuleInterop` setting in tsconfig

## Background

I ran into some issues with the way `sinon` is imported after upgrading from `aws-sdk-client-mock` from `3.0.0` to `4.0.2`. My project has `esModuleInterop` disabled which leads to the following error when running `npx tsc`:

```
src/mockClient.ts:2:8 - error TS1259: Module '"aws-sdk-client-mock2/node_modules/.pnpm/@types+sinon@17.0.3/node_modules/@types/sinon/index"' can only be default-imported using the 'esModuleInterop' flag

2 import sinon, {SinonSandbox, SinonStub} from 'sinon';
         ~~~~~

  ../../node_modules/.pnpm/@types+sinon@17.0.3/node_modules/@types/sinon/index.d.ts:1751:1
    1751 export = Sinon;
         ~~~~~~~~~~~~~~~
    This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.


Found 1 error in src/mockClient.ts:2
```

