### PR TITLE
fix: fix chalk error when using aws-sdk-client-mock-jest package for vitest

### DIFF
--- a/packages/aws-sdk-client-mock-jest/package.json
+++ b/packages/aws-sdk-client-mock-jest/package.json
@@ -65,6 +65,7 @@
   ],
   "dependencies": {
     "@vitest/expect": ">1.6.0",
+    "chalk": "^5.3.0",
     "expect": ">28.1.3",
     "tslib": "^2.1.0"
   },
@@ -76,7 +77,6 @@
     "@types/sinon": "^17.0.3",
     "@vitest/coverage-v8": "^2.1.1",
     "aws-sdk-client-mock": "workspace:*",
-    "chalk": "^5.3.0",
     "expect": "29.7.0",
     "jest-serializer-ansi-escapes": "3.0.0",
     "pretty-ansi": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@vitest/expect':
         specifier: '>1.6.0'
         version: 2.1.1
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
       expect:
         specifier: '>28.1.3'
         version: 29.7.0
@@ -133,9 +136,6 @@ importers:
       aws-sdk-client-mock:
         specifier: workspace:*
         version: link:../aws-sdk-client-mock
-      chalk:
-        specifier: ^5.3.0
-        version: 5.3.0
       jest-serializer-ansi-escapes:
         specifier: 3.0.0
         version: 3.0.0


### PR DESCRIPTION
This is a fix in response to [issue 243](https://github.com/m-radzikowski/aws-sdk-client-mock/issues/243) where when using aws-sdk-client-mock-jest package version 4.1.0 one gets an error that Chalk is not a constructor.

As chalk is being used in the vitest.ts file it needs to be listed as a dependency (instead of a dev dependency)