### PR TITLE
fix: add inlineSource to avoid warning when using aws-sdk-client-mock-jest package with vitest

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     ],
     "moduleResolution": "node",
     "strict": true,
+    "inlineSources": true,
     "sourceMap": true,
     "declaration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This is done because of this issue: https://github.com/m-radzikowski/aws-sdk-client-mock/issues/249